### PR TITLE
feat: Authentication and Authorization

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -80,6 +80,65 @@ type TaskEvent struct {
 	Timestamp time.Time       `json:"timestamp"`
 }
 
+// authMiddleware checks the DASHBOARD_API_KEY env var for API-key based auth (#68, #65)
+func authMiddleware(next http.Handler) http.Handler {
+	apiKey := os.Getenv("DASHBOARD_API_KEY")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If no API key is configured, auth is disabled (local dev)
+		if apiKey == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Skip auth for health endpoint and static files
+		if r.URL.Path == "/api/health" || !strings.HasPrefix(r.URL.Path, "/api/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Auth endpoint: POST /api/auth/login validates the key and returns success
+		if r.URL.Path == "/api/auth/login" && r.Method == "POST" {
+			var body struct {
+				ApiKey string `json:"apiKey"`
+			}
+			if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+				http.Error(w, "Invalid request", http.StatusBadRequest)
+				return
+			}
+			if body.ApiKey != apiKey {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(map[string]string{"error": "Invalid API key"})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"authenticated": true,
+				"message":       "Welcome to the Round Table",
+			})
+			return
+		}
+
+		// Check Authorization header
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			// Also check query param for WebSocket connections
+			if qKey := r.URL.Query().Get("api_key"); qKey != "" {
+				auth = "Bearer " + qKey
+			}
+		}
+
+		if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != apiKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 // rateLimiter is a simple sliding-window rate limiter (#12)
 type rateLimiterT struct {
 	mu       sync.Mutex
@@ -163,8 +222,14 @@ func main() {
 
 	// Router
 	r := mux.NewRouter()
+	r.Use(authMiddleware)
 	r.Use(rateLimiter.middleware)
 	api := r.PathPrefix("/api").Subrouter()
+
+	// Auth endpoint (handled in middleware, but register route for documentation)
+	api.HandleFunc("/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		// Handled by authMiddleware
+	}).Methods("POST")
 
 	// Fleet endpoints
 	api.HandleFunc("/fleet", fleetHandler(namespace)).Methods("GET")
@@ -216,7 +281,7 @@ func main() {
 	// CORS — defaults to same-origin (no origins = same-origin only) (#57)
 	corsOpts := cors.Options{
 		AllowedMethods:   []string{"GET", "POST", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Content-Type"},
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
 		AllowCredentials: false,
 	}
 	if origins := envOr("ALLOWED_ORIGINS", ""); origins != "" {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,7 +25,7 @@
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.6.0",
+        "typescript": "^5.9.3",
         "vite": "^6.0.0"
       }
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.6.0",
+    "typescript": "^5.9.3",
     "vite": "^6.0.0"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Routes, Route, Link, useLocation } from 'react-router-dom'
-import { Swords, Shield, Scroll, GitGraph, BookOpen, Link2, TreePine, Menu, X, LayoutDashboard, Target, DollarSign } from 'lucide-react'
+import { Swords, Shield, Scroll, GitGraph, BookOpen, Link2, TreePine, Menu, X, LayoutDashboard, Target, DollarSign, LogOut } from 'lucide-react'
 import { FleetPage } from './pages/Fleet'
 import { TasksPage } from './pages/Tasks'
 import { BriefingsPage } from './pages/Briefings'
@@ -10,9 +10,11 @@ import { SessionsPage } from './pages/Sessions'
 import { DashboardPage } from './pages/Dashboard'
 import { MissionsPage } from './pages/Missions'
 import { CostDashboardPage } from './pages/CostDashboard'
+import { LoginPage } from './pages/Login'
 import { ToastProvider, useToast } from './components/Toast'
 import { useWebSocket } from './hooks/useWebSocket'
 import { useTaskNotifications } from './hooks/useTaskNotifications'
+import { isAuthenticated, clearApiKey } from './lib/auth'
 
 function NotificationWatcher() {
   const { events } = useWebSocket()
@@ -36,9 +38,60 @@ const navItems = [
 export default function App() {
   const location = useLocation()
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [authed, setAuthed] = useState<boolean | null>(null) // null = checking
+
+  // Check auth state on mount and listen for logout events
+  const checkAuth = useCallback(() => {
+    // Try to reach the API — if no key is configured server-side, we're always authed
+    fetch('/api/health').then(res => {
+      if (res.ok) {
+        // Health is always accessible. Check if auth is required by testing a protected route.
+        fetch('/api/config', {
+          headers: isAuthenticated() ? { 'Authorization': `Bearer ${localStorage.getItem('roundtable_api_key')}` } : {},
+        }).then(r => {
+          if (r.ok) {
+            setAuthed(true)
+          } else if (r.status === 401) {
+            setAuthed(false)
+          } else {
+            // API error but not auth — assume authed (no key configured)
+            setAuthed(true)
+          }
+        }).catch(() => setAuthed(true))
+      } else {
+        setAuthed(true) // Can't reach API, let it fail naturally
+      }
+    }).catch(() => setAuthed(true))
+  }, [])
+
+  useEffect(() => {
+    checkAuth()
+    const onLogout = () => setAuthed(false)
+    window.addEventListener('auth:logout', onLogout)
+    return () => window.removeEventListener('auth:logout', onLogout)
+  }, [checkAuth])
 
   // Close sidebar on navigation (mobile)
   useEffect(() => { setSidebarOpen(false) }, [location.pathname])
+
+  const handleLogout = () => {
+    clearApiKey()
+    setAuthed(false)
+  }
+
+  // Show loading while checking auth
+  if (authed === null) {
+    return (
+      <div className="min-h-screen bg-roundtable-navy flex items-center justify-center">
+        <div className="animate-spin w-8 h-8 border-2 border-roundtable-gold border-t-transparent rounded-full" />
+      </div>
+    )
+  }
+
+  // Show login if not authenticated
+  if (!authed) {
+    return <LoginPage onLogin={() => setAuthed(true)} />
+  }
 
   return (
     <ToastProvider>
@@ -95,7 +148,14 @@ export default function App() {
           })}
         </div>
 
-        <div className="p-4 border-t border-roundtable-steel">
+        <div className="p-4 border-t border-roundtable-steel space-y-2">
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 w-full px-4 py-2 text-sm text-gray-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+            <span>Logout</span>
+          </button>
           <p className="text-xs text-gray-500 text-center">
             ⚔️ Round Table v1.0.0
           </p>

--- a/ui/src/hooks/useFleet.ts
+++ b/ui/src/hooks/useFleet.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { authFetch } from '../lib/auth'
 
 export interface Knight {
   name: string
@@ -20,7 +21,7 @@ export function useFleet(refreshInterval = 10000) {
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch('/api/fleet')
+      const res = await authFetch('/api/fleet')
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
       setKnights(data)

--- a/ui/src/hooks/useKnightSession.ts
+++ b/ui/src/hooks/useKnightSession.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { authFetch } from '../lib/auth'
 
 export interface KnightSessionStats {
   knight: string
@@ -54,7 +55,7 @@ export function useKnightSession() {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/api/fleet/${knight}/session?type=stats`)
+      const res = await authFetch(`/api/fleet/${knight}/session?type=stats`)
       if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`)
       const data = await res.json()
       setStats(data)
@@ -67,7 +68,7 @@ export function useKnightSession() {
 
   const fetchRecent = useCallback(async (knight: string, limit = 20) => {
     try {
-      const res = await fetch(`/api/fleet/${knight}/session?type=recent&limit=${limit}`)
+      const res = await authFetch(`/api/fleet/${knight}/session?type=recent&limit=${limit}`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
       setRecent(data.entries || [])
@@ -78,7 +79,7 @@ export function useKnightSession() {
 
   const fetchTree = useCallback(async (knight: string) => {
     try {
-      const res = await fetch(`/api/fleet/${knight}/session?type=tree`)
+      const res = await authFetch(`/api/fleet/${knight}/session?type=tree`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
       setTree(data.nodes || [])

--- a/ui/src/hooks/useMissions.ts
+++ b/ui/src/hooks/useMissions.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { authFetch } from '../lib/auth'
 
 export interface Mission {
   name: string
@@ -23,7 +24,7 @@ export function useMissions(refreshInterval = 10000) {
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch('/api/missions')
+      const res = await authFetch('/api/missions')
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
       setMissions(data)

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { getApiKey, authFetch } from '../lib/auth'
 
 export interface NatsEvent {
   type: 'task' | 'result'
@@ -35,7 +36,9 @@ export function useWebSocket() {
     }
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws`)
+    const apiKey = getApiKey()
+    const wsUrl = `${protocol}//${window.location.host}/api/ws${apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''}`
+    const ws = new WebSocket(wsUrl)
 
     ws.onopen = () => {
       if (!mountedRef.current) return
@@ -81,7 +84,7 @@ export function useWebSocket() {
     mountedRef.current = true
 
     // Load historical events so there's always something to show
-    fetch('/api/tasks')
+    authFetch('/api/tasks')
       .then((r) => r.json())
       .then((data) => {
         if (!mountedRef.current) return

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,48 @@
+const AUTH_KEY = 'roundtable_api_key'
+
+export function getApiKey(): string | null {
+  return localStorage.getItem(AUTH_KEY)
+}
+
+export function setApiKey(key: string): void {
+  localStorage.setItem(AUTH_KEY, key)
+}
+
+export function clearApiKey(): void {
+  localStorage.removeItem(AUTH_KEY)
+}
+
+export function isAuthenticated(): boolean {
+  return !!getApiKey()
+}
+
+/** Build headers with Authorization for API calls */
+export function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', ...extra }
+  const key = getApiKey()
+  if (key) {
+    headers['Authorization'] = `Bearer ${key}`
+  }
+  return headers
+}
+
+/** Wrapper around fetch that adds auth headers and handles 401 */
+export async function authFetch(url: string, options?: RequestInit): Promise<Response> {
+  const key = getApiKey()
+  const headers = new Headers(options?.headers)
+  if (key) {
+    headers.set('Authorization', `Bearer ${key}`)
+  }
+  if (!headers.has('Content-Type') && options?.body) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const res = await fetch(url, { ...options, headers })
+
+  if (res.status === 401) {
+    clearApiKey()
+    window.dispatchEvent(new Event('auth:logout'))
+  }
+
+  return res
+}

--- a/ui/src/pages/Briefings.tsx
+++ b/ui/src/pages/Briefings.tsx
@@ -1,3 +1,4 @@
+import { authFetch } from '../lib/auth'
 import { useState, useEffect } from 'react'
 import { BookOpen, Calendar, FileText } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
@@ -9,7 +10,7 @@ export function BriefingsPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetch('/api/briefings')
+    authFetch('/api/briefings')
       .then((r) => r.json())
       .then((data) => {
         setBriefings(data.sort().reverse())

--- a/ui/src/pages/Chains.tsx
+++ b/ui/src/pages/Chains.tsx
@@ -1,3 +1,4 @@
+import { authFetch } from '../lib/auth'
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { RefreshCw, ChevronDown, ChevronRight, Clock, Pause, Play } from 'lucide-react'
 import { getKnightConfig } from '../lib/knights'
@@ -273,7 +274,7 @@ export function ChainsPage() {
     abortRef.current = controller
 
     setLoading(true)
-    fetch('/api/chains', { signal: controller.signal })
+    authFetch('/api/chains', { signal: controller.signal })
       .then(r => r.json())
       .then((data: ChainRun[]) => { if (!controller.signal.aborted) setChains(data) })
       .catch((e) => { if (e.name !== 'AbortError') setChains([]) })

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { authFetch } from '../lib/auth'
 import { useState, useEffect, useMemo } from 'react'
 import { Crown, Activity, DollarSign, Zap, AlertTriangle, Link2, ArrowRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
@@ -23,14 +24,14 @@ export function DashboardPage() {
   const [sessionCosts, setSessionCosts] = useState<{ total: number; perKnight: Record<string, number> }>({ total: 0, perKnight: {} })
 
   useEffect(() => {
-    fetch('/api/chains').then(r => r.json()).then(setChains).catch(() => {})
+    authFetch('/api/chains').then(r => r.json()).then(setChains).catch(() => {})
   }, [])
 
   // Fetch cumulative session costs from each knight on load
   useEffect(() => {
     (async () => {
       try {
-        const fleetRes = await fetch('/api/fleet')
+        const fleetRes = await authFetch('/api/fleet')
         const fleetData = await fleetRes.json()
         const names: string[] = (fleetData || []).map((k: any) => k.name)
 

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { Swords, KeyRound, AlertCircle } from 'lucide-react'
+import { setApiKey } from '../lib/auth'
+
+interface LoginPageProps {
+  onLogin: () => void
+}
+
+export function LoginPage({ onLogin }: LoginPageProps) {
+  const [apiKey, setApiKeyValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!apiKey.trim()) return
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: apiKey.trim() }),
+      })
+
+      if (res.ok) {
+        setApiKey(apiKey.trim())
+        onLogin()
+      } else {
+        const data = await res.json().catch(() => ({ error: 'Login failed' }))
+        setError(data.error || 'Invalid API key')
+      }
+    } catch {
+      setError('Connection failed. Is the API running?')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-roundtable-navy flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <Swords className="w-16 h-16 text-roundtable-gold mx-auto mb-4" />
+          <h1 className="text-3xl font-bold text-roundtable-gold">⚔️ The Round Table</h1>
+          <p className="text-gray-400 mt-2">Enter your API key to proceed</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-roundtable-slate border border-roundtable-steel rounded-xl p-6 space-y-4">
+          {error && (
+            <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-lg p-3">
+              <AlertCircle className="w-4 h-4 text-red-400 shrink-0" />
+              <p className="text-red-400 text-sm">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="apiKey" className="block text-sm font-medium text-gray-300 mb-2">
+              <KeyRound className="w-4 h-4 inline mr-1" />
+              API Key
+            </label>
+            <input
+              id="apiKey"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKeyValue(e.target.value)}
+              placeholder="Enter your DASHBOARD_API_KEY"
+              className="w-full px-4 py-3 bg-roundtable-navy border border-roundtable-steel rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-roundtable-gold/50 focus:ring-1 focus:ring-roundtable-gold/30"
+              autoFocus
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !apiKey.trim()}
+            className="w-full py-3 px-4 bg-roundtable-gold/20 border border-roundtable-gold/30 text-roundtable-gold rounded-lg font-medium hover:bg-roundtable-gold/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Authenticating...' : 'Enter the Round Table'}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-gray-600 mt-4">
+          Set DASHBOARD_API_KEY env var on the API to enable authentication
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/Tasks.tsx
+++ b/ui/src/pages/Tasks.tsx
@@ -1,3 +1,4 @@
+import { authFetch } from '../lib/auth'
 import { useState, useEffect } from 'react'
 import { Scroll, Clock, History, RefreshCw, CheckCircle, XCircle } from 'lucide-react'
 import { getKnightConfig, KNIGHT_CONFIG, knightNameForDomain } from '../lib/knights'
@@ -29,7 +30,7 @@ export function TasksPage() {
 
   // Fetch fleet configuration from backend (#60)
   useEffect(() => {
-    fetch('/api/config')
+    authFetch('/api/config')
       .then((r) => r.json())
       .then((data) => {
         if (data.fleetPrefix) setFleetPrefix(data.fleetPrefix)
@@ -39,7 +40,7 @@ export function TasksPage() {
 
   const loadHistory = () => {
     setHistoryLoading(true)
-    fetch('/api/tasks')
+    authFetch('/api/tasks')
       .then((r) => r.json())
       .then((data) => {
         setHistory(data.results || data.tasks || data || [])
@@ -56,7 +57,7 @@ export function TasksPage() {
 
     try {
       const domain = KNIGHT_CONFIG[knight]?.domain || knight
-      const res = await fetch('/api/tasks/dispatch', {
+      const res = await authFetch('/api/tasks/dispatch', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ knight, domain, task }),


### PR DESCRIPTION
## Authentication & Authorization

- API key auth middleware on Go API (uses `DASHBOARD_API_KEY` env var)
- Login page on React frontend
- All API routes protected (except `/api/health`)
- `authFetch` wrapper adds Authorization header to all requests
- WebSocket auth via `api_key` query parameter
- Logout button in sidebar
- Auth is optional: if env var not set, all requests pass through

Closes #68
Closes #65