### PR TITLE
feat: WebSocket events for Missions and Chains

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -72,9 +72,9 @@ type KnightStatus struct {
 	Labels    map[string]string `json:"labels"`
 }
 
-// TaskEvent represents a NATS task/result event
+// TaskEvent represents a NATS task/result/mission/chain event
 type TaskEvent struct {
-	Type      string          `json:"type"` // task, result
+	Type      string          `json:"type"` // task, result, mission, chain
 	Subject   string          `json:"subject"`
 	Data      json.RawMessage `json:"data"`
 	Timestamp time.Time       `json:"timestamp"`
@@ -771,11 +771,61 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
+		// Subscribe to mission status events (#75)
+		missionSub, err := nc.Subscribe(fleetPrefix+".missions.>", func(msg *nats.Msg) {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			event := TaskEvent{
+				Type:      "mission",
+				Subject:   msg.Subject,
+				Data:      msg.Data,
+				Timestamp: time.Now(),
+			}
+			data, _ := json.Marshal(event)
+			safeWrite(data)
+		})
+		if err != nil {
+			log.Printf("NATS mission sub error: %v", err)
+			// Non-fatal: missions subject may not exist yet
+			missionSub = nil
+		}
+
+		// Subscribe to chain progress events (#75)
+		chainSub, err := nc.Subscribe(fleetPrefix+".chains.>", func(msg *nats.Msg) {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			event := TaskEvent{
+				Type:      "chain",
+				Subject:   msg.Subject,
+				Data:      msg.Data,
+				Timestamp: time.Now(),
+			}
+			data, _ := json.Marshal(event)
+			safeWrite(data)
+		})
+		if err != nil {
+			log.Printf("NATS chain sub error: %v", err)
+			// Non-fatal
+			chainSub = nil
+		}
+
 		// Cleanup on exit
 		defer func() {
 			close(done)
 			taskSub.Unsubscribe()
 			resultSub.Unsubscribe()
+			if missionSub != nil {
+				missionSub.Unsubscribe()
+			}
+			if chainSub != nil {
+				chainSub.Unsubscribe()
+			}
 			writeMu.Lock()
 			closed = true
 			writeMu.Unlock()

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { getApiKey, authFetch } from '../lib/auth'
 
 export interface NatsEvent {
-  type: 'task' | 'result'
+  type: 'task' | 'result' | 'mission' | 'chain'
   subject: string
   data: unknown
   timestamp: string
@@ -90,7 +90,7 @@ export function useWebSocket() {
         if (!mountedRef.current) return
         const historical: NatsEvent[] = (data.results || [])
           .map((r: { type?: string; subject?: string; data?: unknown; timestamp?: string }) => ({
-            type: (r.type || 'result') as 'task' | 'result',
+            type: (r.type || 'result') as NatsEvent['type'],
             subject: r.subject || '',
             data: r.data,
             timestamp: r.timestamp || new Date().toISOString(),


### PR DESCRIPTION
## WebSocket Events for Missions and Chains

Extends the existing WebSocket handler to broadcast mission and chain events.

- Subscribe to `fleetPrefix.missions.>` for mission status changes
- Subscribe to `fleetPrefix.chains.>` for chain progress events  
- Frontend NatsEvent type updated to include 'mission' and 'chain'
- Non-fatal: if subjects don't exist yet, WS still works for tasks/results

Closes #75