### PR TITLE
feat: NATS KV results API + UI integration

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -251,6 +251,12 @@ func main() {
 	api.HandleFunc("/missions", missionCreateHandler(namespace)).Methods("POST")
 	api.HandleFunc("/missions/{name}", missionDeleteHandler(namespace)).Methods("DELETE")
 
+	// KV endpoints (NATS KV store)
+	api.HandleFunc("/missions/{name}/results", missionResultsHandler()).Methods("GET")
+	api.HandleFunc("/chains/{name}/steps/{step}/output", chainStepOutputHandler()).Methods("GET")
+	api.HandleFunc("/kv/{bucket}/keys", kvKeysHandler()).Methods("GET")
+	api.HandleFunc("/kv/{bucket}/{key}", kvGetHandler()).Methods("GET")
+
 	// RoundTable endpoints
 	api.HandleFunc("/roundtables", roundTablesHandler(namespace)).Methods("GET")
 	api.HandleFunc("/roundtables/{name}", roundTableDetailHandler(namespace)).Methods("GET")
@@ -1384,6 +1390,124 @@ func parseRoundTableResource(obj map[string]interface{}) RoundTableSummary {
 	}
 
 	return rt
+}
+
+// --- NATS KV helpers and handlers ---
+
+// getOrCreateKVBucket returns a NATS KV bucket handle, creating it if needed.
+func getOrCreateKVBucket(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := js.KeyValue(ctx, bucket)
+	if err != nil {
+		// Try to create it
+		kv, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+			Bucket:      bucket,
+			Description: fmt.Sprintf("Round Table %s store", bucket),
+			History:     3,
+			TTL:         30 * 24 * time.Hour,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("KV bucket %s: %w", bucket, err)
+		}
+	}
+	return kv, nil
+}
+
+// validBucketName matches safe KV bucket names
+var validBucketName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,62}$`)
+
+func missionResultsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := mux.Vars(r)["name"]
+		if !validKnightName.MatchString(name) {
+			http.Error(w, "Invalid mission name", http.StatusBadRequest)
+			return
+		}
+		kv, err := getOrCreateKVBucket(r.Context(), "mission-results")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		entry, err := kv.Get(r.Context(), name)
+		if err != nil {
+			http.Error(w, "Results not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(entry.Value())
+	}
+}
+
+func chainStepOutputHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		name := vars["name"]
+		step := vars["step"]
+		if !validKnightName.MatchString(name) || !validKnightName.MatchString(step) {
+			http.Error(w, "Invalid name", http.StatusBadRequest)
+			return
+		}
+		kv, err := getOrCreateKVBucket(r.Context(), "chain-outputs")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		key := name + "." + step
+		entry, err := kv.Get(r.Context(), key)
+		if err != nil {
+			http.Error(w, "Output not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(entry.Value())
+	}
+}
+
+func kvKeysHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bucket := mux.Vars(r)["bucket"]
+		if !validBucketName.MatchString(bucket) {
+			http.Error(w, "Invalid bucket name", http.StatusBadRequest)
+			return
+		}
+		kv, err := getOrCreateKVBucket(r.Context(), bucket)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		keys, err := kv.Keys(r.Context())
+		if err != nil {
+			// No keys found
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]string{})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(keys)
+	}
+}
+
+func kvGetHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		bucket := vars["bucket"]
+		key := vars["key"]
+		if !validBucketName.MatchString(bucket) {
+			http.Error(w, "Invalid bucket name", http.StatusBadRequest)
+			return
+		}
+		kv, err := getOrCreateKVBucket(r.Context(), bucket)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		entry, err := kv.Get(r.Context(), key)
+		if err != nil {
+			http.Error(w, "Key not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(entry.Value())
+	}
 }
 
 // Helper functions for unstructured K8s objects

--- a/ui/src/components/MissionCard.tsx
+++ b/ui/src/components/MissionCard.tsx
@@ -1,4 +1,6 @@
-import { Target, Clock, Users, Link2, DollarSign } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { Target, Clock, Users, Link2, DollarSign, FileText } from 'lucide-react'
+import { authFetch } from '../lib/auth'
 import type { Mission } from '../hooks/useMissions'
 import { MissionPhaseBadge } from './MissionPhaseBadge'
 import { getKnightConfig } from '../lib/knights'
@@ -33,7 +35,31 @@ function formatDuration(start: string | null, end: string | null): string {
   return `${hours}h ${mins}m`
 }
 
+function MissionResults({ name }: { name: string }) {
+  const [data, setData] = useState<Record<string, unknown> | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    authFetch(`/api/missions/${name}/results`)
+      .then(r => { if (!r.ok) throw new Error('Not found'); return r.json() })
+      .then(d => setData(d))
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [name])
+
+  if (loading) return <p className="text-xs text-gray-500 py-2">Loading results...</p>
+  if (error) return <p className="text-xs text-gray-500 py-2">No results stored yet</p>
+
+  return (
+    <pre className="text-xs text-gray-300 whitespace-pre-wrap max-h-64 overflow-auto bg-roundtable-navy rounded p-3 border border-roundtable-gold/20">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  )
+}
+
 export function MissionCard({ mission, onClick }: MissionCardProps) {
+  const [showResults, setShowResults] = useState(false)
   const isComplete = mission.phase === 'Succeeded' || mission.phase === 'Failed' || mission.phase === 'Expired'
   
   // Calculate budget usage percentage
@@ -117,10 +143,27 @@ export function MissionCard({ mission, onClick }: MissionCardProps) {
         <span className="text-xs text-gray-500">
           RoundTable: <span className="text-gray-400">{mission.roundTableRef}</span>
         </span>
-        <span className="text-xs text-gray-600 group-hover:text-roundtable-gold/60 transition-colors">
-          view details →
-        </span>
+        <div className="flex items-center gap-2">
+          {isComplete && (
+            <button
+              onClick={(e) => { e.stopPropagation(); setShowResults(r => !r) }}
+              className="flex items-center gap-1 text-xs text-roundtable-gold/60 hover:text-roundtable-gold transition-colors"
+            >
+              <FileText className="w-3 h-3" />
+              {showResults ? 'hide results' : 'results'}
+            </button>
+          )}
+          <span className="text-xs text-gray-600 group-hover:text-roundtable-gold/60 transition-colors">
+            view details →
+          </span>
+        </div>
       </div>
+
+      {showResults && (
+        <div className="mt-3 pt-3 border-t border-roundtable-steel/50">
+          <MissionResults name={mission.name} />
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/src/pages/Chains.tsx
+++ b/ui/src/pages/Chains.tsx
@@ -172,7 +172,42 @@ function StepDAG({ steps, currentStep }: { steps: ChainStep[]; currentStep: stri
   )
 }
 
-function StepDetail({ step }: { step: ChainStep }) {
+function StepKVOutput({ chainName, stepName }: { chainName: string; stepName: string }) {
+  const [data, setData] = useState<Record<string, unknown> | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    setError('')
+    authFetch(`/api/chains/${chainName}/steps/${stepName}/output`)
+      .then(r => { if (!r.ok) throw new Error('Not found'); return r.json() })
+      .then(d => setData(d))
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [chainName, stepName])
+
+  if (loading) return <p className="text-xs text-gray-500 mt-2">Loading full output from KV...</p>
+  if (error) return null // No KV data yet, that's fine
+  if (!data) return null
+
+  const output = (data.output as string) || ''
+  const duration = (data.duration as string) || ''
+
+  return (
+    <div className="mt-3">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-xs text-roundtable-gold uppercase font-semibold">📦 Full Output (NATS KV)</span>
+        {duration && <span className="text-xs text-gray-500">⏱ {duration}</span>}
+      </div>
+      <pre className="text-xs text-gray-300 whitespace-pre-wrap max-h-96 overflow-auto bg-roundtable-navy rounded p-3 border border-roundtable-gold/20">
+        {output}
+      </pre>
+    </div>
+  )
+}
+
+function StepDetail({ step, chainName }: { step: ChainStep; chainName: string }) {
   const cfg = getKnightConfig(step.knight)
   return (
     <div className="bg-roundtable-navy border border-roundtable-steel rounded-lg p-4 mt-2">
@@ -194,11 +229,14 @@ function StepDetail({ step }: { step: ChainStep }) {
       </div>
       {step.result && (
         <div>
-          <span className="text-xs text-gray-500 uppercase">Result</span>
+          <span className="text-xs text-gray-500 uppercase">Result (truncated)</span>
           <pre className="text-xs text-gray-400 whitespace-pre-wrap max-h-64 overflow-auto mt-1 bg-roundtable-slate rounded p-3 border border-roundtable-steel/50">
             {step.result}
           </pre>
         </div>
+      )}
+      {(step.phase === 'Completed' || step.phase === 'Succeeded') && chainName && (
+        <StepKVOutput chainName={chainName} stepName={step.name} />
       )}
     </div>
   )
@@ -252,7 +290,7 @@ function ChainCard({ chain }: { chain: ChainRun }) {
               )
             })}
           </div>
-          {activeStep && <StepDetail step={activeStep} />}
+          {activeStep && <StepDetail step={activeStep} chainName={chain.name} />}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Adds NATS KV store endpoints to the API and wires them into the frontend for viewing mission results and chain step outputs.

### API Endpoints
- `GET /api/missions/:name/results` — Read from `mission-results` KV bucket
- `GET /api/chains/:name/steps/:step/output` — Read from `chain-outputs` KV bucket  
- `GET /api/kv/:bucket/keys` — List keys in any bucket
- `GET /api/kv/:bucket/:key` — Get value from any bucket

### Frontend
- Chain step detail shows full output from NATS KV (for completed steps)
- Mission cards have a 'results' toggle for completed missions
- Both use the `authFetch` pattern for API key auth

### Related
- Companion to dapperdivers/roundtable PR #39 (NATS KV migration)
- Operator now stores chain step outputs to `chain-outputs` KV bucket