### PR TITLE
ci: notify dapper-cluster on image push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,3 +58,16 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  notify-cluster:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch image update to dapper-cluster
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CLUSTER_PAT }}
+          repository: DapperDivers/dapper-cluster
+          event-type: image-update
+          client-payload: '{"image": "roundtable-ui", "tag": "${{ github.sha }}", "repo": "${{ github.repository }}"}'


### PR DESCRIPTION
Adds `notify-cluster` job that dispatches to dapper-cluster after build+push, triggering automated image tag update PRs.

Requires `CLUSTER_PAT` secret.