### PR TITLE
fix: security vulns and frontend bugs from automated audit

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -80,6 +80,12 @@ type TaskEvent struct {
 	Timestamp time.Time       `json:"timestamp"`
 }
 
+// validK8sName validates Kubernetes resource names to prevent label selector injection.
+var validK8sName = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// validSessionTypes is the whitelist of allowed session type query parameters.
+var validSessionTypes = map[string]bool{"stats": true, "recent": true, "tree": true}
+
 // authMiddleware checks the DASHBOARD_API_KEY env var for API-key based auth (#68, #65)
 func authMiddleware(next http.Handler) http.Handler {
 	apiKey := os.Getenv("DASHBOARD_API_KEY")
@@ -318,6 +324,10 @@ func main() {
 }
 
 func buildKnightStatus(pod corev1.Pod) KnightStatus {
+	labels := pod.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	status := "offline"
 	var restarts int32
 	ready := false
@@ -332,8 +342,8 @@ func buildKnightStatus(pod corev1.Pod) KnightStatus {
 		}
 	}
 	ks := KnightStatus{
-		Name:     pod.Labels["app.kubernetes.io/instance"],
-		Domain:   pod.Labels["roundtable.io/domain"],
+		Name:     labels["app.kubernetes.io/instance"],
+		Domain:   labels["roundtable.io/domain"],
 		Status:   status,
 		Ready:    ready,
 		Restarts: restarts,
@@ -408,6 +418,11 @@ func knightHandler(namespace string) http.HandlerFunc {
 		vars := mux.Vars(r)
 		name := vars["knight"]
 
+		if !validK8sName.MatchString(name) {
+			http.Error(w, "Invalid knight name", http.StatusBadRequest)
+			return
+		}
+
 		if k8sClient == nil {
 			http.Error(w, "Kubernetes not available", http.StatusServiceUnavailable)
 			return
@@ -464,6 +479,11 @@ func knightLogsHandler(namespace string) http.HandlerFunc {
 		name := vars["knight"]
 		lines := int64(100)
 
+		if !validK8sName.MatchString(name) {
+			http.Error(w, "Invalid knight name", http.StatusBadRequest)
+			return
+		}
+
 		if k8sClient == nil {
 			http.Error(w, "Kubernetes not available", http.StatusServiceUnavailable)
 			return
@@ -515,6 +535,10 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 		reqType := r.URL.Query().Get("type")
 		if reqType == "" {
 			reqType = "stats"
+		}
+		if !validSessionTypes[reqType] {
+			http.Error(w, "Invalid session type (allowed: stats, recent, tree)", http.StatusBadRequest)
+			return
 		}
 
 		if nc == nil {

--- a/ui/src/pages/Architecture.tsx
+++ b/ui/src/pages/Architecture.tsx
@@ -65,7 +65,7 @@ export function ArchitecturePage() {
       <div className="mt-6 bg-roundtable-slate border border-roundtable-steel rounded-xl p-6">
         <h2 className="text-lg font-bold text-white mb-4">Tech Stack</h2>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-          <div><h4 className="text-gray-400 mb-1">Frontend</h4><p className="text-white">React 19 + TypeScript</p><p className="text-gray-500">Vite, Tailwind CSS</p></div>
+          <div><h4 className="text-gray-400 mb-1">Frontend</h4><p className="text-white">React 18 + TypeScript</p><p className="text-gray-500">Vite, Tailwind CSS</p></div>
           <div><h4 className="text-gray-400 mb-1">API</h4><p className="text-white">Go 1.23</p><p className="text-gray-500">Gorilla Mux, WebSocket</p></div>
           <div><h4 className="text-gray-400 mb-1">Messaging</h4><p className="text-white">NATS + JetStream</p><p className="text-gray-500">Pub/Sub, persistence</p></div>
           <div><h4 className="text-gray-400 mb-1">Orchestration</h4><p className="text-white">Kubernetes CRDs</p><p className="text-gray-500">Custom operator</p></div>

--- a/ui/src/pages/CostDashboard.tsx
+++ b/ui/src/pages/CostDashboard.tsx
@@ -242,8 +242,8 @@ export function CostDashboardPage() {
           ) : (
             <div className="space-y-2">
               {dailyCosts.map(({ date, cost }) => {
-                const maxCost = Math.max(...dailyCosts.map(d => d.cost))
-                const barWidth = (cost / maxCost) * 100
+                const maxCost = Math.max(...dailyCosts.map(d => d.cost), 1)
+                const barWidth = maxCost > 0 ? (cost / maxCost) * 100 : 0
                 return (
                   <div key={date} className="space-y-1">
                     <div className="flex items-center justify-between text-sm">

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -127,7 +127,7 @@ export function DashboardPage() {
         <div className="bg-roundtable-slate border border-roundtable-steel rounded-xl p-5">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-white">🏰 Fleet</h2>
-            <Link to="/" className="text-xs text-roundtable-gold hover:underline flex items-center gap-1">
+            <Link to="/fleet" className="text-xs text-roundtable-gold hover:underline flex items-center gap-1">
               View all <ArrowRight className="w-3 h-3" />
             </Link>
           </div>


### PR DESCRIPTION
Fixes from the knight-driven bug hunt chain:

**Security (API):**
- K8s label selector injection via unvalidated knight names (2 endpoints)
- NATS injection via unsanitized session type query parameter
- Nil pointer dereference on pods with no labels

**Frontend:**
- Dashboard Fleet link pointing to / instead of /fleet
- Architecture page showing React 19 (it's 18.3.1)
- Division by zero in cost trend chart bars