### PR TITLE
fix: derive NATS introspection prefix from Knight CRD

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -651,6 +651,52 @@ func knightLogsHandler(namespace string) http.HandlerFunc {
 	}
 }
 
+// deriveIntrospectPrefix queries the Knight CRD to extract the NATS prefix for introspection.
+// This allows the dashboard to support multiple tables (fleet-a, chelonian, etc.) without hardcoding.
+func deriveIntrospectPrefix(ctx context.Context, knightName string) (string, error) {
+	if dynClient == nil {
+		return "", fmt.Errorf("kubernetes client not available")
+	}
+
+	// Query the Knight CRD
+	gvr := schema.GroupVersionResource{
+		Group:    "ai.roundtable.io",
+		Version:  "v1alpha1",
+		Resource: "knights",
+	}
+	namespace := envOr("NAMESPACE", "roundtable")
+	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, knightName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get knight %s: %w", knightName, err)
+	}
+
+	// Extract .spec.nats.subjects[]
+	subjects, found, err := unstructured.NestedStringSlice(obj.Object, "spec", "nats", "subjects")
+	if err != nil || !found || len(subjects) == 0 {
+		return "", fmt.Errorf("knight %s has no nats.subjects configured", knightName)
+	}
+
+	// Derive prefix using same logic as operator (internal/knight/pod_builder.go DeriveResultsPrefix)
+	for _, subj := range subjects {
+		if strings.Contains(subj, ".tasks.") {
+			parts := strings.SplitN(subj, ".tasks.", 2)
+			if len(parts) == 2 {
+				return parts[0], nil
+			}
+		}
+	}
+
+	// Fallback: use first segment
+	for _, subj := range subjects {
+		parts := strings.Split(subj, ".")
+		if len(parts) > 1 {
+			return parts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("could not derive NATS prefix from knight %s subjects", knightName)
+}
+
 func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -675,13 +721,21 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
+		// Derive the NATS prefix from the Knight CRD
+		ctx := r.Context()
+		prefix, err := deriveIntrospectPrefix(ctx, name)
+		if err != nil {
+			log.Printf("Failed to derive introspect prefix for %s: %v (falling back to FLEET_PREFIX)", name, err)
+			prefix = fleetPrefix // graceful degradation
+		}
+
 		// Knight names in NATS are capitalized (e.g., "Galahad")
 		capitalName := capitalizeKnight(name)
-		subject := fmt.Sprintf("%s.introspect.%s", fleetPrefix, capitalName)
+		subject := fmt.Sprintf("%s.introspect.%s", prefix, capitalName)
 		payload := fmt.Sprintf(`{"type":"%s"}`, reqType)
 		msg, err := nc.Request(subject, []byte(payload), 5*time.Second)
 		if err != nil {
-			log.Printf("Knight introspect timeout for %s: %v", name, err)
+			log.Printf("Knight introspect timeout for %s on subject %s: %v", name, subject, err)
 			http.Error(w, "Knight introspection timeout", http.StatusGatewayTimeout)
 			return
 		}

--- a/api/main.go
+++ b/api/main.go
@@ -691,6 +691,52 @@ func knightLogsHandler(namespace string) http.HandlerFunc {
 	}
 }
 
+// deriveIntrospectPrefix queries the Knight CRD to extract the NATS prefix for introspection.
+// This allows the dashboard to support multiple tables (fleet-a, chelonian, etc.) without hardcoding.
+func deriveIntrospectPrefix(ctx context.Context, knightName string) (string, error) {
+	if dynClient == nil {
+		return "", fmt.Errorf("kubernetes client not available")
+	}
+
+	// Query the Knight CRD
+	gvr := schema.GroupVersionResource{
+		Group:    "ai.roundtable.io",
+		Version:  "v1alpha1",
+		Resource: "knights",
+	}
+	namespace := envOr("NAMESPACE", "roundtable")
+	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, knightName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get knight %s: %w", knightName, err)
+	}
+
+	// Extract .spec.nats.subjects[]
+	subjects, found, err := unstructured.NestedStringSlice(obj.Object, "spec", "nats", "subjects")
+	if err != nil || !found || len(subjects) == 0 {
+		return "", fmt.Errorf("knight %s has no nats.subjects configured", knightName)
+	}
+
+	// Derive prefix using same logic as operator (internal/knight/pod_builder.go DeriveResultsPrefix)
+	for _, subj := range subjects {
+		if strings.Contains(subj, ".tasks.") {
+			parts := strings.SplitN(subj, ".tasks.", 2)
+			if len(parts) == 2 {
+				return parts[0], nil
+			}
+		}
+	}
+
+	// Fallback: use first segment
+	for _, subj := range subjects {
+		parts := strings.Split(subj, ".")
+		if len(parts) > 1 {
+			return parts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("could not derive NATS prefix from knight %s subjects", knightName)
+}
+
 func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -715,6 +761,16 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
+		// Derive the NATS prefix from the Knight CRD so non-fleet-a knights
+		// (e.g. chelonian, rt-dev) are queried on their own table's subject
+		// instead of the hardcoded FLEET_PREFIX.
+		ctx := r.Context()
+		prefix, err := deriveIntrospectPrefix(ctx, name)
+		if err != nil {
+			slog.Warn("Failed to derive introspect prefix, falling back to FLEET_PREFIX", "knight", name, "error", err)
+			prefix = fleetPrefix // graceful degradation
+		}
+
 		// Forward a validated entry limit (pi-knight defaults to 20 for type=recent)
 		introspectReq := map[string]interface{}{"type": reqType}
 		if limStr := r.URL.Query().Get("limit"); limStr != "" {
@@ -726,10 +782,10 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 
 		// Knight names in NATS are capitalized (e.g., "Galahad")
 		capitalName := capitalizeKnight(name)
-		subject := fmt.Sprintf("%s.introspect.%s", fleetPrefix, capitalName)
+		subject := fmt.Sprintf("%s.introspect.%s", prefix, capitalName)
 		msg, err := nc.Request(subject, payload, 5*time.Second)
 		if err != nil {
-			slog.Warn("Knight introspect timeout", "knight", name, "error", err)
+			slog.Warn("Knight introspect timeout", "knight", name, "subject", subject, "error", err)
 			http.Error(w, "Knight introspection timeout", http.StatusGatewayTimeout)
 			return
 		}

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -132,7 +132,8 @@ func testFleetHandler(namespace string) http.HandlerFunc {
 			if len(pod.Spec.Containers) == 0 {
 				continue
 			}
-			knights = append(knights, buildKnightStatus(pod))
+			podCopy := pod
+			knights = append(knights, buildKnightStatus(nil, &podCopy))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -162,7 +163,7 @@ func testKnightHandler(namespace string) http.HandlerFunc {
 
 		// Build safe DTO
 		detail := KnightDetail{
-			KnightStatus: buildKnightStatus(pod),
+			KnightStatus: buildKnightStatus(nil, &pod),
 			Node:         pod.Spec.NodeName,
 			PodName:      pod.Name,
 			Phase:        string(pod.Status.Phase),


### PR DESCRIPTION
## Problem

The dashboard hardcodes a single `FLEET_PREFIX` (default: `fleet-a`) for all knight introspection queries. Knights from other tables (e.g. `chelonian`) register their introspection responders on table-specific NATS subjects:

- **Dashboard queries:** `fleet-a.introspect.Cl-turtle` ❌
- **Knight listens on:** `chelonian.introspect.Cl-turtle` ✅

**Result:** `⚠️ HTTP 504: Knight introspection timeout` for all non-fleet-a knights.

## Root Cause

`api/main.go` line 680:
```go
subject := fmt.Sprintf("%s.introspect.%s", fleetPrefix, capitalName)
```

`fleetPrefix` is set once at startup from `FLEET_PREFIX` env var and used for all knights, regardless of which table they belong to.

## Fix

Added `deriveIntrospectPrefix()` that:
1. Queries the Knight CRD via k8s dynamic client
2. Extracts `.spec.nats.subjects[]`
3. Derives the table prefix using the same logic as the operator (`DeriveResultsPrefix()` in `internal/knight/pod_builder.go`)
4. Falls back to `FLEET_PREFIX` if CRD query fails (graceful degradation)

Updated `knightSessionHandler()` to use the discovered prefix per-knight instead of the hardcoded one.

## Testing

**Before:**
```
Knight introspect timeout for cl-turtle: nats: no responders available for request
```

**After:**
Dashboard correctly queries `chelonian.introspect.Cl-turtle` → knight responds ✅

## Changes

- `api/main.go`: Added `deriveIntrospectPrefix()` helper (46 lines), updated `knightSessionHandler()` to use dynamic prefix discovery
