### PR TITLE
fix: repair Go test build after CR-based fleet rewrite

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -36,7 +36,7 @@ var validKnightName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,62}$`)
 var (
 	nc        *nats.Conn
 	js        jetstream.JetStream
-	k8sClient *kubernetes.Clientset
+	k8sClient kubernetes.Interface
 	dynClient dynamic.Interface
 	upgrader  = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
@@ -240,15 +240,18 @@ func main() {
 	if err != nil {
 		log.Printf("WARNING: K8s in-cluster config failed (running outside cluster?): %v", err)
 	} else {
-		k8sClient, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			log.Printf("WARNING: K8s client creation failed: %v", err)
+		// Assign globals only on success — a typed-nil client would defeat the
+		// k8sClient != nil availability checks in handlers
+		if cs, csErr := kubernetes.NewForConfig(config); csErr != nil {
+			log.Printf("WARNING: K8s client creation failed: %v", csErr)
 		} else {
+			k8sClient = cs
 			log.Println("Kubernetes client connected")
 		}
-		dynClient, err = dynamic.NewForConfig(config)
-		if err != nil {
-			log.Printf("WARNING: Dynamic K8s client creation failed: %v", err)
+		if dc, dcErr := dynamic.NewForConfig(config); dcErr != nil {
+			log.Printf("WARNING: Dynamic K8s client creation failed: %v", dcErr)
+		} else {
+			dynClient = dc
 		}
 	}
 
@@ -764,6 +767,11 @@ func taskDispatchHandler(fleetPrefix string) http.HandlerFunc {
 		}
 		if len(req.Task) == 0 || len(req.Task) > 10000 {
 			http.Error(w, "Task must be 1-10000 characters", http.StatusBadRequest)
+			return
+		}
+
+		if nc == nil {
+			http.Error(w, "NATS not available", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -26,10 +26,10 @@ var fakeK8sClient *k8sfake.Clientset
 
 // setupTestRouter creates a test router with mocked dependencies
 func setupTestRouter() *mux.Router {
-	// Initialize mock K8s client
+	// Initialize mock K8s client and inject it into the handlers' global
 	fakeK8sClient = k8sfake.NewSimpleClientset()
-	// The handlers will use fakeK8sClient instead of k8sClient
-	
+	k8sClient = fakeK8sClient
+
 	// Initialize mock dynamic client with proper scheme
 	scheme := runtime.NewScheme()
 	
@@ -82,9 +82,11 @@ func setupTestRouter() *mux.Router {
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	}).Methods("GET")
 	
-	api.HandleFunc("/fleet", testFleetHandler(namespace)).Methods("GET")
-	api.HandleFunc("/fleet/{knight}", testKnightHandler(namespace)).Methods("GET")
+	api.HandleFunc("/fleet", fleetHandler(namespace)).Methods("GET")
+	api.HandleFunc("/fleet/{knight}", knightHandler(namespace)).Methods("GET")
 	api.HandleFunc("/fleet/{knight}/session", knightSessionHandler(fleetPrefix)).Methods("GET")
+
+	api.HandleFunc("/tasks/dispatch", taskDispatchHandler(fleetPrefix)).Methods("POST")
 	
 	api.HandleFunc("/chains", chainsHandler(namespace)).Methods("GET")
 	api.HandleFunc("/chains/{name}", chainDetailHandler(namespace)).Methods("GET")
@@ -107,92 +109,26 @@ func setupTestRouter() *mux.Router {
 	return r
 }
 
-// Test wrapper handlers that use the fake K8s client
-func testFleetHandler(namespace string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if fakeK8sClient == nil {
-			http.Error(w, "Kubernetes not available", http.StatusServiceUnavailable)
-			return
-		}
-
-		pods, err := fakeK8sClient.CoreV1().Pods(namespace).List(r.Context(), metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/name=knight",
-		})
-		if err != nil {
-			http.Error(w, "Failed to list fleet", http.StatusInternalServerError)
-			return
-		}
-
-		knights := []KnightStatus{}
-		for _, pod := range pods.Items {
-			// Skip CronJob pods and pods with no containers
-			if _, ok := pod.Labels["job-name"]; ok {
-				continue
-			}
-			if len(pod.Spec.Containers) == 0 {
-				continue
-			}
-			knights = append(knights, buildKnightStatus(pod))
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(knights)
+// makeTestKnightCR builds a minimal Knight CR for handler tests.
+func makeTestKnightCR(name, namespace, domain string) *unstructured.Unstructured {
+	knight := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "ai.roundtable.io/v1alpha1",
+			"kind":       "Knight",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"domain": domain,
+			},
+			"status": map[string]interface{}{
+				"phase": "Ready",
+			},
+		},
 	}
-}
-
-func testKnightHandler(namespace string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		name := vars["knight"]
-
-		if fakeK8sClient == nil {
-			http.Error(w, "Kubernetes not available", http.StatusServiceUnavailable)
-			return
-		}
-
-		pods, err := fakeK8sClient.CoreV1().Pods(namespace).List(r.Context(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=knight,app.kubernetes.io/instance=%s", name),
-		})
-		if err != nil || len(pods.Items) == 0 {
-			http.Error(w, "Knight not found", http.StatusNotFound)
-			return
-		}
-
-		pod := pods.Items[0]
-
-		// Build safe DTO
-		detail := KnightDetail{
-			KnightStatus: buildKnightStatus(pod),
-			Node:         pod.Spec.NodeName,
-			PodName:      pod.Name,
-			Phase:        string(pod.Status.Phase),
-		}
-		if !pod.CreationTimestamp.IsZero() {
-			t := pod.CreationTimestamp.Time
-			detail.StartTime = &t
-		}
-		for _, c := range pod.Status.ContainerStatuses {
-			state := "unknown"
-			if c.State.Running != nil {
-				state = "running"
-			} else if c.State.Waiting != nil {
-				state = "waiting:" + c.State.Waiting.Reason
-			} else if c.State.Terminated != nil {
-				state = "terminated:" + c.State.Terminated.Reason
-			}
-			detail.Containers = append(detail.Containers, ContainerDetail{
-				Name: c.Name, Image: c.Image, Ready: c.Ready, State: state, Started: c.Started,
-			})
-		}
-		for _, cond := range pod.Status.Conditions {
-			detail.Conditions = append(detail.Conditions, PodCondition{
-				Type: string(cond.Type), Status: string(cond.Status),
-			})
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(detail)
-	}
+	knight.SetCreationTimestamp(metav1.Now())
+	return knight
 }
 
 // TestHealthEndpoint tests the /api/health endpoint
@@ -301,12 +237,18 @@ func TestFleetHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create test pod: %v", err)
 	}
-	
+
+	// The fleet handler is driven by Knight CRs — pods only enrich them
+	_, err = dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, makeTestKnightCR("galahad", namespace, "security"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create knight CR: %v", err)
+	}
+
 	req := httptest.NewRequest("GET", "/api/fleet", nil)
 	w := httptest.NewRecorder()
-	
+
 	router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", w.Code)
 	}
@@ -413,7 +355,10 @@ func TestKnightHandler(t *testing.T) {
 	}
 	
 	fakeK8sClient.CoreV1().Pods(namespace).Create(nil, pod, metav1.CreateOptions{})
-	
+	if _, err := dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, makeTestKnightCR("tristan", namespace, "infrastructure"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create knight CR: %v", err)
+	}
+
 	tests := []struct {
 		name           string
 		knightName     string


### PR DESCRIPTION
## Summary

`go test ./api` has been failing to build since the CR-based fleet rewrite (#106) — `main_test.go` still used pod-scraping wrappers calling `buildKnightStatus(pod)` with the old signature, and assigned `k8sfake.Clientset` to the `*kubernetes.Clientset` global. This blocked test verification for all API changes.

## Changes

- `k8sClient` global is now `kubernetes.Interface` so the fake clientset injects cleanly; K8s clients are only assigned on successful creation (a typed-nil interface would defeat the `k8sClient != nil` availability checks in handlers)
- Removed the stale `testFleetHandler`/`testKnightHandler` wrappers; `TestFleetHandler`/`TestKnightHandler` now exercise the **real** handlers, with Knight CRs seeded via the fake dynamic client
- Registered `/tasks/dispatch` in the test router (its validation tests had never actually run) and added the missing NATS-availability guard in `taskDispatchHandler` — it previously panicked on dispatch if NATS was down

## Testing

- `go test ./...` passes (was: build failure)
- `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)