### PR TITLE
fix: /api/tasks returns newest results with producer timestamps

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -109,6 +109,20 @@ type TaskEvent struct {
 	Timestamp time.Time       `json:"timestamp"`
 }
 
+// eventTimestamp extracts the producer timestamp from an event payload so the
+// same message gets the same timestamp whether it arrives live over the
+// WebSocket or is replayed from JetStream history — the frontend dedup key is
+// subject+timestamp. Falls back to now for payloads without a timestamp.
+func eventTimestamp(data []byte) time.Time {
+	var payload struct {
+		Timestamp time.Time `json:"timestamp"`
+	}
+	if err := json.Unmarshal(data, &payload); err == nil && !payload.Timestamp.IsZero() {
+		return payload.Timestamp
+	}
+	return time.Now()
+}
+
 // validK8sName validates Kubernetes resource names to prevent label selector injection.
 var validK8sName = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
@@ -705,14 +719,25 @@ func taskHistoryHandler(fleetPrefix, streamName string) http.HandlerFunc {
 			return
 		}
 
-		info, _ := stream.Info(ctx)
+		info, err := stream.Info(ctx)
+		if err != nil {
+			log.Printf("JetStream stream info error: %v", err)
+			http.Error(w, "Task history unavailable", http.StatusInternalServerError)
+			return
+		}
 		results := []TaskEvent{}
 
-		// Get last N messages
-		limit := 50
-		// Use a named ephemeral consumer with InactiveThreshold for auto-cleanup (#54)
+		// Get the newest N messages: result subjects are unique per task, so
+		// start limit messages back from the stream tail and read forward
+		const limit = 50
+		startSeq := uint64(1)
+		if info.State.LastSeq > limit {
+			startSeq = info.State.LastSeq - limit + 1
+		}
+		// Ephemeral consumer with InactiveThreshold for auto-cleanup (#54)
 		cons, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-			DeliverPolicy:     jetstream.DeliverLastPerSubjectPolicy,
+			DeliverPolicy:     jetstream.DeliverByStartSequencePolicy,
+			OptStartSeq:       startSeq,
 			FilterSubject:     fleetPrefix + ".results.>",
 			AckPolicy:         jetstream.AckNonePolicy,
 			InactiveThreshold: 30 * time.Second,
@@ -727,14 +752,14 @@ func taskHistoryHandler(fleetPrefix, streamName string) http.HandlerFunc {
 			return
 		}
 
-		msgs, _ := cons.Fetch(limit, jetstream.FetchMaxWait(5*time.Second))
+		msgs, _ := cons.FetchNoWait(limit)
 		if msgs != nil {
 			for msg := range msgs.Messages() {
 				results = append(results, TaskEvent{
 					Type:      "result",
 					Subject:   msg.Subject(),
 					Data:      msg.Data(),
-					Timestamp: time.Now(),
+					Timestamp: eventTimestamp(msg.Data()),
 				})
 			}
 		}
@@ -899,7 +924,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "task",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -920,7 +945,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "result",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -943,7 +968,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "mission",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -965,7 +990,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "chain",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -937,6 +937,28 @@ func TestCapitalizeKnight(t *testing.T) {
 	}
 }
 
+// TestEventTimestamp tests payload timestamp extraction for event dedup
+func TestEventTimestamp(t *testing.T) {
+	want := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
+	payload := []byte(`{"task_id":"galahad-ui-1","success":true,"timestamp":"2026-06-01T12:30:00Z"}`)
+	if got := eventTimestamp(payload); !got.Equal(want) {
+		t.Errorf("eventTimestamp = %v, expected %v", got, want)
+	}
+
+	// Missing / invalid timestamps fall back to roughly now
+	for _, data := range [][]byte{
+		[]byte(`{"task_id":"x"}`),
+		[]byte(`{"timestamp":"not-a-time"}`),
+		[]byte(`not json`),
+		nil,
+	} {
+		got := eventTimestamp(data)
+		if time.Since(got) > time.Minute || time.Until(got) > time.Minute {
+			t.Errorf("eventTimestamp(%q) = %v, expected approximately now", data, got)
+		}
+	}
+}
+
 // TestEnvOr tests the environment variable helper
 func TestEnvOr(t *testing.T) {
 	os.Setenv("TEST_VAR", "value")


### PR DESCRIPTION
Closes #122. Stacked on #129 (test build fix) — merge that first; this PR's base is `fix/go-test-build`.

## Problem

`taskHistoryHandler` had three bugs (details in #122):

1. `DeliverLastPerSubjectPolicy` + unique per-task result subjects = "last per subject" is *every* message, so `Fetch(50)` returned the **oldest 50** results. Recent results never appeared once the stream passed 50 messages.
2. Events were stamped `time.Now()` at fetch time instead of the producer timestamp from the result payload — the frontend's `subject:timestamp` dedup key never matched across refetches or against the live WS copy, causing duplicate feed entries, double-counted dashboard costs, and time-range filters treating ancient results as current.
3. `stream.Info` error was ignored and the nil result dereferenced (panic on transient errors).

## Changes

- Consume from `lastSeq - limit + 1` forward (`DeliverByStartSequencePolicy`) so the newest N results are returned
- New `eventTimestamp()` helper extracts the payload `timestamp` (pi-knight sets it on every result); used by **both** the history endpoint and the live WebSocket bridge so the same message keys identically in both paths
- `stream.Info` errors now return 500 instead of panicking
- `FetchNoWait` replaces the 5s blocking fetch — history is a point-in-time read

## Testing

- Added `TestEventTimestamp` (payload extraction + fallback)
- `go test ./...` passes, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)