### PR TITLE
fix: parse result subjects per pi-knight convention, attribute by payload knight

### DIFF
--- a/ui/src/components/FleetGraph.tsx
+++ b/ui/src/components/FleetGraph.tsx
@@ -14,6 +14,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { buildKnightConfigFromFleet, getKnightConfig, knightNameForDomain } from '../lib/knights'
+import { parseEvent } from '../lib/events'
 import type { NatsEvent } from '../hooks/useWebSocket'
 import type { Knight } from '../hooks/useFleet'
 
@@ -189,17 +190,12 @@ function buildEdges(
 
   // Count recent messages per edge pair
   for (const event of recentEvents.slice(0, 50)) {
-    const parts = event.subject.split('.')
-    const domain = parts[2] || ''
-    const isTask = parts[1] === 'tasks'
-    const knight = knightNameForDomain(domain)
+    const parsed = parseEvent(event)
+    const isTask = event.type === 'task'
+    const knight = parsed.knight
     if (!knight) continue
 
-    const data = (typeof event.data === 'string'
-      ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-      : event.data || {}) as Record<string, unknown>
-
-    const from = (data.from as string) || ''
+    const from = (parsed.data.from as string) || ''
     const sourceKnight = knightNameForDomain(from)
 
     let edgeKey: string
@@ -289,23 +285,16 @@ export function FleetGraph({ knights, events, connected, knightStatuses = {}, on
 
     // Process events to compute activity
     for (const event of events) {
-      const parts = event.subject.split('.')
-      const domain = parts[2] || ''
-      const knight = knightNameForDomain(domain)
+      const parsed = parseEvent(event)
+      const knight = parsed.knight
       if (!knight || !act[knight]) continue
 
       if (event.type === 'task') {
         act[knight].recentTasks++
-        const data = (typeof event.data === 'string'
-          ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-          : event.data || {}) as Record<string, unknown>
-        const taskId = (data.task_id as string) || ''
+        const taskId = (parsed.data.task_id as string) || parsed.taskId
         if (taskId) act[knight].pendingTasks.add(taskId)
       } else {
-        const data = (typeof event.data === 'string'
-          ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-          : event.data || {}) as Record<string, unknown>
-        const taskId = (data.task_id as string) || ''
+        const taskId = (parsed.data.task_id as string) || parsed.taskId
         if (taskId) act[knight].pendingTasks.delete(taskId)
       }
     }

--- a/ui/src/hooks/useTaskNotifications.ts
+++ b/ui/src/hooks/useTaskNotifications.ts
@@ -1,14 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { NatsEvent } from './useWebSocket'
-import { knightNameForDomain, getKnightConfig } from '../lib/knights'
-
-interface ResultData {
-  success?: boolean
-  error?: string
-  cost?: number
-  duration?: string
-  domain?: string
-}
+import { getKnightConfig } from '../lib/knights'
+import { parseEvent, resultFailureReason } from '../lib/events'
 
 export function useTaskNotifications(
   events: NatsEvent[],
@@ -32,23 +25,20 @@ export function useTaskNotifications(
     for (const event of newEvents) {
       if (event.type !== 'result') continue
 
-      const data = event.data as ResultData
-      // Extract domain from subject like "roundtable.security.result"
-      const parts = event.subject.split('.')
-      const domain = data?.domain || parts[2] || parts[1] || 'unknown'
-      const knightName = knightNameForDomain(domain)
-      const config = knightName ? getKnightConfig(knightName) : getKnightConfig(domain)
-      const displayName = knightName
-        ? knightName.charAt(0).toUpperCase() + knightName.slice(1)
-        : domain
+      const { knight, data } = parseEvent(event)
+      const config = getKnightConfig(knight || 'unknown')
+      const displayName = knight
+        ? knight.charAt(0).toUpperCase() + knight.slice(1)
+        : 'Unknown knight'
 
-      if (data.success === false || data.error) {
-        const reason = data.error || 'unknown error'
+      const reason = resultFailureReason(data)
+      if (reason) {
         addToast(`❌ ${displayName} failed: ${reason}`, 'error')
       } else {
         const cost = typeof data.cost === 'number' ? data.cost : null
         const costStr = cost ? ` ($${cost.toFixed(4)})` : ''
-        addToast(`${config.emoji} ${displayName} completed ${domain} task${costStr}`, 'success')
+        const domainStr = knight ? ` ${config.domain}` : ''
+        addToast(`${config.emoji} ${displayName} completed a${domainStr} task${costStr}`, 'success')
       }
     }
   }, [events, addToast])

--- a/ui/src/lib/events.test.ts
+++ b/ui/src/lib/events.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { parseEvent, parseEventData, resultFailureReason } from './events'
+import type { NatsEvent } from '../hooks/useWebSocket'
+
+function makeEvent(type: NatsEvent['type'], subject: string, data: unknown): NatsEvent {
+  return { type, subject, data, timestamp: '2026-06-10T12:00:00Z' }
+}
+
+describe('parseEvent', () => {
+  it('parses result subjects as <fleet>.results.<taskId> with knight from payload', () => {
+    const event = makeEvent('result', 'fleet-a.results.galahad-ui-1749500000000', {
+      task_id: 'galahad-ui-1749500000000',
+      knight: 'Galahad',
+      success: true,
+      cost: 0.0123,
+    })
+    const parsed = parseEvent(event)
+    expect(parsed.knight).toBe('galahad')
+    expect(parsed.domain).toBeNull()
+    expect(parsed.taskId).toBe('galahad-ui-1749500000000')
+  })
+
+  it('falls back to the subject for taskId when payload lacks task_id', () => {
+    const event = makeEvent('result', 'fleet-a.results.task-42', { knight: 'Kay', success: true })
+    expect(parseEvent(event).taskId).toBe('task-42')
+  })
+
+  it('returns null knight for results without a payload knight field', () => {
+    const event = makeEvent('result', 'fleet-a.results.task-42', { success: true })
+    expect(parseEvent(event).knight).toBeNull()
+  })
+
+  it('parses task subjects as <fleet>.tasks.<domain>.<taskId>', () => {
+    const event = makeEvent('task', 'fleet-a.tasks.security.galahad-ui-1', { task: 'scan' })
+    const parsed = parseEvent(event)
+    expect(parsed.domain).toBe('security')
+    expect(parsed.knight).toBe('galahad')
+    expect(parsed.taskId).toBe('galahad-ui-1')
+  })
+
+  it('handles JSON-string payloads', () => {
+    const event = makeEvent('result', 'fleet-a.results.t1', '{"knight":"Tristan","success":false,"result":"boom"}')
+    const parsed = parseEvent(event)
+    expect(parsed.knight).toBe('tristan')
+    expect(parsed.data.success).toBe(false)
+  })
+
+  it('lowercases hyphenated knight names to match CR names', () => {
+    const event = makeEvent('result', 'fleet-a.results.t2', { knight: 'Coder-1', success: true })
+    expect(parseEvent(event).knight).toBe('coder-1')
+  })
+})
+
+describe('parseEventData', () => {
+  it('wraps unparseable strings as raw', () => {
+    expect(parseEventData('not json')).toEqual({ raw: 'not json' })
+  })
+
+  it('returns empty object for null/undefined', () => {
+    expect(parseEventData(null)).toEqual({})
+    expect(parseEventData(undefined)).toEqual({})
+  })
+})
+
+describe('resultFailureReason', () => {
+  it('returns null for successful results', () => {
+    expect(resultFailureReason({ success: true, result: 'done' })).toBeNull()
+    expect(resultFailureReason({})).toBeNull()
+  })
+
+  it('extracts the failure text from result (pi-knight has no error field)', () => {
+    expect(resultFailureReason({ success: false, result: 'Task failed: timeout' })).toBe('Task failed: timeout')
+  })
+
+  it('truncates long failure text', () => {
+    const reason = resultFailureReason({ success: false, result: 'x'.repeat(500) })
+    expect(reason!.length).toBeLessThanOrEqual(161)
+    expect(reason!.endsWith('…')).toBe(true)
+  })
+
+  it('falls back to unknown error when result is empty', () => {
+    expect(resultFailureReason({ success: false })).toBe('unknown error')
+  })
+})

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -1,0 +1,78 @@
+// Shared NATS event parsing.
+//
+// Subject formats (pi-knight + dashboard API conventions):
+//   tasks:    <fleet>.tasks.<domain>.<taskId>
+//   results:  <fleet>.results.<taskId>          — no domain segment!
+//
+// Result payloads (pi-knight publishResult) carry the knight name directly
+// (capitalized CR name, e.g. "Galahad") plus success/result/cost/tokens/
+// duration_ms/model. There is no `domain` or `error` field — failure text
+// lives in `result` when success === false.
+import { knightNameForDomain } from './knights'
+import type { NatsEvent } from '../hooks/useWebSocket'
+
+export interface ResultData {
+  task_id?: string
+  knight?: string
+  success?: boolean
+  result?: string
+  duration_ms?: number
+  cost?: number
+  tokens?: { input?: number; output?: number; total?: number }
+  model?: string
+  timestamp?: string
+}
+
+/** Parse event payload, which may arrive as a JSON string or an object. */
+export function parseEventData(data: unknown): Record<string, unknown> {
+  if (typeof data === 'string') {
+    try { return JSON.parse(data) } catch { return { raw: data } }
+  }
+  return (data as Record<string, unknown>) || {}
+}
+
+export interface ParsedEvent {
+  /** Lowercase knight CR name (matches fleet/KNIGHT_CONFIG keys), if resolvable */
+  knight: string | null
+  /** Task domain — only present on task events (results carry no domain) */
+  domain: string | null
+  taskId: string
+  data: Record<string, unknown>
+}
+
+/** Resolve knight/domain/taskId for an event, honoring the per-type subject format. */
+export function parseEvent(event: NatsEvent): ParsedEvent {
+  const parts = event.subject.split('.')
+  const data = parseEventData(event.data)
+
+  if (event.type === 'result') {
+    const payloadKnight = typeof data.knight === 'string' && data.knight ? data.knight.toLowerCase() : null
+    return {
+      knight: payloadKnight,
+      domain: null,
+      taskId: (typeof data.task_id === 'string' && data.task_id) || parts[2] || '',
+      data,
+    }
+  }
+
+  if (event.type === 'task') {
+    const domain = parts[2] || null
+    return {
+      knight: domain ? knightNameForDomain(domain) : null,
+      domain,
+      taskId: parts[3] || '',
+      data,
+    }
+  }
+
+  // mission/chain events: subject is <fleet>.<type>.<name...>
+  return { knight: null, domain: null, taskId: '', data }
+}
+
+/** Failure reason for a failed result event, or null if it succeeded. */
+export function resultFailureReason(data: Record<string, unknown>): string | null {
+  if (data.success !== false) return null
+  const text = typeof data.result === 'string' ? data.result.trim() : ''
+  if (!text) return 'unknown error'
+  return text.length > 160 ? text.slice(0, 160) + '…' : text
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -4,7 +4,8 @@ import { Crown, Activity, DollarSign, Zap, AlertTriangle, Link2, ArrowRight, Tre
 import { Link } from 'react-router-dom'
 import { useFleet } from '../hooks/useFleet'
 import { useWebSocket } from '../hooks/useWebSocket'
-import { getKnightConfig, knightNameForDomain, KNIGHT_NAMES } from '../lib/knights'
+import { getKnightConfig, KNIGHT_NAMES } from '../lib/knights'
+import { parseEvent } from '../lib/events'
 
 interface ChainSummary {
   name: string
@@ -82,17 +83,13 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
       if (e.type !== 'result') continue
       totalResults++
 
-      const data = (typeof e.data === 'string'
-        ? (() => { try { return JSON.parse(e.data as string) } catch { return {} } })()
-        : e.data || {}) as Record<string, unknown>
+      const { knight, data } = parseEvent(e)
 
       if (data.success === false) failures++
       const cost = typeof data.cost === 'number' ? data.cost : 0
       totalCost += cost
 
-      const parts = e.subject.split('.')
-      const name = knightNameForDomain(parts[2] || '')
-      if (name) knightCosts[name] = (knightCosts[name] || 0) + cost
+      if (knight) knightCosts[knight] = (knightCosts[knight] || 0) + cost
     }
 
     // Merge cumulative session costs (primary) with live WS costs (supplementary)
@@ -114,18 +111,14 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
     const entries: CostEntry[] = []
     for (const event of events) {
       if (event.type !== 'result') continue
-      const data = (typeof event.data === 'string'
-        ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-        : event.data || {}) as Record<string, unknown>
+      const { knight, taskId, data } = parseEvent(event)
       const cost = typeof data.cost === 'number' ? data.cost : 0
       if (cost <= 0) continue
-      const parts = event.subject.split('.')
-      const domain = parts[2] || ''
       entries.push({
-        knight: knightNameForDomain(domain) || domain,
+        knight: knight || 'unknown',
         cost,
         timestamp: event.timestamp,
-        taskId: parts[3] || '',
+        taskId,
         success: data.success !== false,
       })
     }
@@ -291,14 +284,13 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
           </div>
           <div className="space-y-1.5 max-h-64 overflow-y-auto">
             {events.slice(0, 10).map((e, i) => {
-              const parts = e.subject.split('.')
-              const name = knightNameForDomain(parts[2] || '')
-              const cfg = name ? getKnightConfig(name) : null
+              const { knight, domain } = parseEvent(e)
+              const cfg = knight ? getKnightConfig(knight) : null
               return (
                 <div key={i} className="flex items-center gap-2 text-xs py-1">
                   <span>{e.type === 'task' ? '📤' : '📥'}</span>
                   <span>{cfg?.emoji || '🤖'}</span>
-                  <span className="text-gray-400 truncate flex-1">{name || parts[2]}</span>
+                  <span className="text-gray-400 truncate flex-1">{knight || domain || e.type}</span>
                   <span className="text-gray-600">{new Date(e.timestamp).toLocaleTimeString()}</span>
                 </div>
               )

--- a/ui/src/pages/Fleet.tsx
+++ b/ui/src/pages/Fleet.tsx
@@ -5,7 +5,8 @@ import type { Knight } from '../hooks/useFleet'
 import { KnightCard } from '../components/KnightCard'
 import { KnightDetailDrawer } from '../components/KnightDetailDrawer'
 import { useWebSocket } from '../hooks/useWebSocket'
-import { knightNameForDomain, getKnightConfig } from '../lib/knights'
+import { getKnightConfig } from '../lib/knights'
+import { parseEvent, resultFailureReason } from '../lib/events'
 
 export function FleetPage() {
   const { knights, loading, error, refresh } = useFleet()
@@ -29,9 +30,7 @@ export function FleetPage() {
     })
 
     for (const event of windowedEvents) {
-      const parts = event.subject.split('.')
-      const domain = parts[2] || ''
-      const name = knightNameForDomain(domain)
+      const name = parseEvent(event).knight
       if (!name) continue
 
       const ts = new Date(event.timestamp).getTime()
@@ -64,17 +63,16 @@ export function FleetPage() {
 
     // Mark busy: has task but fewer results than tasks in recent window
     for (const event of windowedEvents) {
-      const parts = event.subject.split('.')
-      const domain = parts[2] || ''
-      const name = knightNameForDomain(domain)
-      if (!name || event.type !== 'task') continue
+      if (event.type !== 'task') continue
+      const name = parseEvent(event).knight
+      if (!name) continue
       const ts = new Date(event.timestamp).getTime()
       if (now - ts > 60000) continue // only last 60s for busy detection
       if (activity[name]) {
         // Check if there's a result after this task
         const hasResult = events.some(e =>
           e.type === 'result' &&
-          knightNameForDomain(e.subject.split('.')[2] || '') === name &&
+          parseEvent(e).knight === name &&
           new Date(e.timestamp).getTime() > ts
         )
         if (!hasResult) activity[name].busy = true
@@ -92,17 +90,12 @@ export function FleetPage() {
 
     for (const event of events) {
       if (event.type !== 'result') continue
-      const data = (typeof event.data === 'string'
-        ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-        : event.data || {}) as Record<string, unknown>
+      const { knight, data } = parseEvent(event)
       const cost = typeof data.cost === 'number' ? data.cost : 0
       if (cost > 0) {
         totalCost += cost
         taskCount++
-        const parts = event.subject.split('.')
-        const domain = parts[2] || ''
-        const name = knightNameForDomain(domain)
-        if (name) perKnight[name] = (perKnight[name] || 0) + cost
+        if (knight) perKnight[knight] = (perKnight[knight] || 0) + cost
       }
     }
     const topSpender = Object.entries(perKnight).sort((a, b) => b[1] - a[1])[0]
@@ -192,13 +185,7 @@ export function FleetPage() {
       {/* Error War Room (#45) */}
       {(() => {
         const errors = events
-          .filter(e => {
-            if (e.type !== 'result') return false
-            const data = (typeof e.data === 'string'
-              ? (() => { try { return JSON.parse(e.data as string) } catch { return {} } })()
-              : e.data || {}) as Record<string, unknown>
-            return data.success === false || !!data.error
-          })
+          .filter(e => e.type === 'result' && parseEvent(e).data.success === false)
           .slice(0, 5)
 
         if (errors.length === 0) return null
@@ -208,18 +195,13 @@ export function FleetPage() {
             <h3 className="text-sm font-medium text-red-400 mb-3">⚠️ Recent Failures ({errors.length})</h3>
             <div className="space-y-2">
               {errors.map((e, i) => {
-                const data = (typeof e.data === 'string'
-                  ? (() => { try { return JSON.parse(e.data as string) } catch { return {} } })()
-                  : e.data || {}) as Record<string, unknown>
-                const parts = e.subject.split('.')
-                const domain = parts[2] || ''
-                const name = knightNameForDomain(domain)
-                const cfg = name ? getKnightConfig(name) : null
+                const { knight, data } = parseEvent(e)
+                const cfg = knight ? getKnightConfig(knight) : null
                 return (
                   <div key={i} className="flex items-center gap-2 text-xs">
                     <span>{cfg?.emoji || '🤖'}</span>
-                    <span className="text-gray-300 capitalize">{name || domain}</span>
-                    <span className="text-red-400 truncate flex-1">{(data.error as string) || 'Task failed'}</span>
+                    <span className="text-gray-300 capitalize">{knight || 'unknown'}</span>
+                    <span className="text-red-400 truncate flex-1">{resultFailureReason(data) || 'Task failed'}</span>
                     <span className="text-gray-600 flex-shrink-0">{new Date(e.timestamp).toLocaleTimeString()}</span>
                   </div>
                 )

--- a/ui/src/pages/Live.tsx
+++ b/ui/src/pages/Live.tsx
@@ -4,18 +4,9 @@ import { useWebSocket, type NatsEvent } from '../hooks/useWebSocket'
 import { useFleet } from '../hooks/useFleet'
 import type { Knight } from '../hooks/useFleet'
 import { getKnightConfig, KNIGHT_CONFIG, knightNameForDomain } from '../lib/knights'
+import { parseEvent, parseEventData } from '../lib/events'
 import { FleetGraph } from '../components/FleetGraph'
 import { KnightDetailDrawer } from '../components/KnightDetailDrawer'
-
-function parseSubject(subject: string) {
-  const parts = subject.split('.')
-  return { fleet: parts[0] || '', type: parts[1] || '', domain: parts[2] || '', taskId: parts[3] || '' }
-}
-
-function parseEventData(data: unknown): Record<string, unknown> {
-  if (typeof data === 'string') { try { return JSON.parse(data) } catch { return { raw: data } } }
-  return (data as Record<string, unknown>) || {}
-}
 
 export function LivePage() {
   const { events, connected } = useWebSocket()
@@ -59,13 +50,14 @@ export function LivePage() {
 
   const filteredEvents = useMemo(() => {
     return events.filter((event) => {
-      const parsed = parseSubject(event.subject)
       if (filterType && event.type !== filterType) return false
-      if (filterDomain && parsed.domain !== filterDomain) return false
-      if (filterKnight) {
-        const knight = knightNameForDomain(parsed.domain)
-        if (knight !== filterKnight) return false
+      const parsed = parseEvent(event)
+      if (filterDomain) {
+        // Results carry no domain — fall back to the knight's configured domain
+        const domain = parsed.domain || (parsed.knight ? getKnightConfig(parsed.knight).domain : '')
+        if (domain !== filterDomain) return false
       }
+      if (filterKnight && parsed.knight !== filterKnight) return false
       return true
     })
   }, [events, filterKnight, filterType, filterDomain])
@@ -126,12 +118,9 @@ export function LivePage() {
       {(() => {
         const comms: Record<string, number> = {}
         for (const event of filteredEvents.slice(0, 100)) {
-          const data = (typeof event.data === 'string'
-            ? (() => { try { return JSON.parse(event.data as string) } catch { return {} } })()
-            : event.data || {}) as Record<string, unknown>
-          const from = knightNameForDomain((data.from as string) || '')
-          const parts = event.subject.split('.')
-          const to = knightNameForDomain(parts[2] || '')
+          const parsed = parseEvent(event)
+          const from = knightNameForDomain((parsed.data.from as string) || '')
+          const to = parsed.knight
           if (from && to && from !== to) {
             const key = `${from} → ${to}`
             comms[key] = (comms[key] || 0) + 1
@@ -219,16 +208,15 @@ export function LivePage() {
 function EventCard({ event, index, expanded, onToggle }: {
   event: NatsEvent; index: number; expanded: boolean; onToggle: () => void
 }) {
-  const parsed = parseSubject(event.subject)
-  const knight = knightNameForDomain(parsed.domain)
+  const { knight, data } = parseEvent(event)
   const cfg = knight ? getKnightConfig(knight) : null
-  const data = parseEventData(event.data)
   const isTask = event.type === 'task'
-  const taskText = (data.task as string) || (data.summary as string) || ''
+  const taskText = (data.task as string) || (data.result as string) || (data.summary as string) || ''
   const success = data.success as boolean | undefined
   const cost = typeof data.cost === 'number' ? data.cost : undefined
-  const duration = typeof data.duration === 'number' ? data.duration : undefined
-  const toolCalls = typeof data.toolCalls === 'number' ? data.toolCalls : undefined
+  // pi-knight publishes duration_ms and tool_calls
+  const durationMs = typeof data.duration_ms === 'number' ? data.duration_ms : undefined
+  const toolCalls = typeof data.tool_calls === 'number' ? data.tool_calls : undefined
 
   return (
     <div
@@ -253,8 +241,8 @@ function EventCard({ event, index, expanded, onToggle }: {
         {!isTask && cost !== undefined && (
           <span className="text-gray-500">${cost.toFixed(4)}</span>
         )}
-        {!isTask && duration !== undefined && (
-          <span className="text-gray-500">{duration}s</span>
+        {!isTask && durationMs !== undefined && (
+          <span className="text-gray-500">{(durationMs / 1000).toFixed(1)}s</span>
         )}
         {!isTask && toolCalls !== undefined && (
           <span className="text-gray-500">🔧{toolCalls}</span>


### PR DESCRIPTION
Closes #121.

## Problem

pi-knight publishes results to `<fleet>.results.<taskId>` — **no domain segment** — and the payload carries `knight` (capitalized CR name), `success`, `result`, `cost`, `duration_ms`, `tool_calls`. There is no `domain` or `error` field; failure text lives in `result`.

The UI assumed `<fleet>.results.<domain>.<taskId>` in five places and read payload fields that don't exist, so knight attribution silently failed for every result event (details in #121).

## Changes

- New `ui/src/lib/events.ts` — shared `parseEvent` / `parseEventData` / `resultFailureReason` documenting both subject formats: knight comes from the payload for results, from the domain segment for tasks
- `useTaskNotifications`: toasts now name the knight and show the real failure reason (truncated) instead of "unknown error"
- `Dashboard`: live per-knight cost attribution and Recent Activity now resolve correctly
- `Fleet`: busy detection and sparkline attribution fixed; Error War Room shows the actual failure text
- `Live`/`FleetGraph`: flow view and graph edges resolve knights from payloads; EventCard reads `duration_ms`/`tool_calls` (was `duration`/`toolCalls`) and shows result text
- Unit tests for the parser (12 cases)

## Testing

- `npm run build` passes
- `npm test`: 72 passed (+12 new) — the 14 failures in `KnightCard.test.tsx`/`Dashboard.test.tsx` are pre-existing on `main` (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)