### PR TITLE
fix: toast notifications track event identity and skip seeded history

### DIFF
--- a/ui/src/hooks/useTaskNotifications.test.ts
+++ b/ui/src/hooks/useTaskNotifications.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useTaskNotifications } from './useTaskNotifications'
+import type { NatsEvent } from './useWebSocket'
+
+let seq = 0
+function makeResult(live: boolean, success = true): NatsEvent {
+  seq++
+  return {
+    type: 'result',
+    subject: `fleet-a.results.task-${seq}`,
+    data: { task_id: `task-${seq}`, knight: 'Galahad', success, cost: 0.01 },
+    timestamp: `2026-06-10T12:00:${String(seq % 60).padStart(2, '0')}.${seq}Z`,
+    live,
+  }
+}
+
+describe('useTaskNotifications', () => {
+  it('toasts live result events exactly once', () => {
+    const addToast = vi.fn()
+    const live = makeResult(true)
+    const { rerender } = renderHook(
+      ({ events }: { events: NatsEvent[] }) => useTaskNotifications(events, addToast),
+      { initialProps: { events: [] as NatsEvent[] } },
+    )
+
+    rerender({ events: [live] })
+    expect(addToast).toHaveBeenCalledTimes(1)
+    expect(addToast.mock.calls[0][0]).toContain('Galahad')
+
+    // Same array again — no duplicate toast
+    rerender({ events: [live] })
+    expect(addToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not toast seeded history events (no live flag)', () => {
+    const addToast = vi.fn()
+    const history = Array.from({ length: 50 }, () => makeResult(false))
+    history.forEach((h) => delete h.live)
+
+    const { rerender } = renderHook(
+      ({ events }: { events: NatsEvent[] }) => useTaskNotifications(events, addToast),
+      { initialProps: { events: [] as NatsEvent[] } },
+    )
+    rerender({ events: history })
+    expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('keeps toasting when the feed is at its cap (constant length)', () => {
+    const addToast = vi.fn()
+    const feed = Array.from({ length: 200 }, () => makeResult(true))
+
+    const { rerender } = renderHook(
+      ({ events }: { events: NatsEvent[] }) => useTaskNotifications(events, addToast),
+      { initialProps: { events: feed } },
+    )
+    expect(addToast).toHaveBeenCalledTimes(200)
+    addToast.mockClear()
+
+    // New event prepended, oldest dropped — length unchanged at 200
+    const next = [makeResult(true), ...feed.slice(0, 199)]
+    rerender({ events: next })
+    expect(addToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the failure reason from the result field', () => {
+    const addToast = vi.fn()
+    const failed = makeResult(true, false)
+    ;(failed.data as Record<string, unknown>).result = 'Task failed: model timeout'
+
+    const { rerender } = renderHook(
+      ({ events }: { events: NatsEvent[] }) => useTaskNotifications(events, addToast),
+      { initialProps: { events: [] as NatsEvent[] } },
+    )
+    rerender({ events: [failed] })
+    expect(addToast).toHaveBeenCalledWith(expect.stringContaining('Task failed: model timeout'), 'error')
+  })
+})

--- a/ui/src/hooks/useTaskNotifications.ts
+++ b/ui/src/hooks/useTaskNotifications.ts
@@ -1,29 +1,36 @@
 import { useEffect, useRef } from 'react'
-import type { NatsEvent } from './useWebSocket'
+import { eventKey, type NatsEvent } from './useWebSocket'
 import { getKnightConfig } from '../lib/knights'
 import { parseEvent, resultFailureReason } from '../lib/events'
 
+const MAX_SEEN_KEYS = 1000
+
+/**
+ * Toast on live result events. Tracks event identity (not array length —
+ * the feed is capped, so its length stops changing once full) and only
+ * notifies for events that arrived over the WebSocket after mount, never
+ * for seeded history.
+ */
 export function useTaskNotifications(
   events: NatsEvent[],
   addToast: (message: string, type: 'success' | 'info' | 'warning' | 'error') => void,
 ) {
-  const seenCount = useRef(0)
+  const seenKeys = useRef(new Set<string>())
 
   useEffect(() => {
-    if (events.length === 0) return
+    const seen = seenKeys.current
+    const fresh = events.filter((e) => !seen.has(eventKey(e)))
+    if (fresh.length === 0) return
 
-    // Events are prepended (newest first), so new events are at indices 0..newCount-1
-    const newCount = events.length - seenCount.current
-    if (newCount <= 0) {
-      seenCount.current = events.length
-      return
+    for (const e of fresh) seen.add(eventKey(e))
+    // Bound the seen set; Sets iterate in insertion order, so keep the newest
+    if (seen.size > MAX_SEEN_KEYS) {
+      const keys = Array.from(seen)
+      seenKeys.current = new Set(keys.slice(keys.length - MAX_SEEN_KEYS / 2))
     }
 
-    const newEvents = events.slice(0, newCount)
-    seenCount.current = events.length
-
-    for (const event of newEvents) {
-      if (event.type !== 'result') continue
+    for (const event of fresh) {
+      if (!event.live || event.type !== 'result') continue
 
       const { knight, data } = parseEvent(event)
       const config = getKnightConfig(knight || 'unknown')

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -6,6 +6,8 @@ export interface NatsEvent {
   subject: string
   data: unknown
   timestamp: string
+  /** True when the event arrived over the live WebSocket (vs seeded from history) */
+  live?: boolean
 }
 
 const MAX_EVENTS = 200
@@ -18,7 +20,7 @@ function jitter(ms: number): number {
 }
 
 /** Generate a dedup key from an event's subject + timestamp */
-function eventKey(e: NatsEvent): string {
+export function eventKey(e: NatsEvent): string {
   return `${e.subject}:${e.timestamp}`
 }
 
@@ -71,7 +73,7 @@ export function useWebSocket() {
     ws.onmessage = (e) => {
       if (!mountedRef.current) return
       try {
-        const event: NatsEvent = JSON.parse(e.data)
+        const event: NatsEvent = { ...JSON.parse(e.data), live: true }
         const key = eventKey(event)
         if (seenEvents.current.has(key)) return // deduplicate
         seenEvents.current.add(key)


### PR DESCRIPTION
Closes #123. Stacked on #131 (result parsing) — merge that first; this PR's base is `fix/result-subject-parsing`.

## Problem

`useTaskNotifications` tracked a **count** of seen events, not identity:

1. On mount, the `/api/tasks` history seed appended up to 50 events → all of them fired "completed" toasts on every page load.
2. Once the feed reached `MAX_EVENTS` (200), new events are prepended while old ones drop off — the array length never changes, so `newCount` was always 0 and **notifications went permanently silent** after any busy period.

## Changes

- `useWebSocket` flags events arriving over the socket with `live: true` (history seeds don't get the flag) and exports `eventKey`
- `useTaskNotifications` tracks seen event keys in a bounded set and only toasts **live** result events — never history, never duplicates, regardless of feed length

## Testing

Four new hook tests cover: single toast per live event, no toasts for history seeds, toasting continues at the feed cap, and failure-reason extraction. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)