### PR TITLE
fix: make knight session stats reliable under auth and slow knights

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -678,11 +679,19 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
+		// Forward a validated entry limit (pi-knight defaults to 20 for type=recent)
+		introspectReq := map[string]interface{}{"type": reqType}
+		if limStr := r.URL.Query().Get("limit"); limStr != "" {
+			if lim, limErr := strconv.Atoi(limStr); limErr == nil && lim > 0 && lim <= 500 {
+				introspectReq["limit"] = lim
+			}
+		}
+		payload, _ := json.Marshal(introspectReq)
+
 		// Knight names in NATS are capitalized (e.g., "Galahad")
 		capitalName := capitalizeKnight(name)
 		subject := fmt.Sprintf("%s.introspect.%s", fleetPrefix, capitalName)
-		payload := fmt.Sprintf(`{"type":"%s"}`, reqType)
-		msg, err := nc.Request(subject, []byte(payload), 5*time.Second)
+		msg, err := nc.Request(subject, payload, 5*time.Second)
 		if err != nil {
 			log.Printf("Knight introspect timeout for %s: %v", name, err)
 			http.Error(w, "Knight introspection timeout", http.StatusGatewayTimeout)

--- a/ui/src/hooks/useKnightSession.ts
+++ b/ui/src/hooks/useKnightSession.ts
@@ -45,8 +45,12 @@ export interface SessionTreeNode {
   summary: string
 }
 
+// Client-side timeout must exceed the API's 5s NATS introspect timeout —
+// otherwise the client aborts first and a slow knight looks "unsupported"
+export const SESSION_TIMEOUT_MS = 8000
+
 // Helper to add timeout to fetch requests
-async function fetchWithTimeout(url: string, timeoutMs = 5000): Promise<Response | null> {
+export async function fetchWithTimeout(url: string, timeoutMs = SESSION_TIMEOUT_MS): Promise<Response | null> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   
@@ -70,7 +74,7 @@ export function useKnightSession() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchStats = useCallback(async (knight: string, timeoutMs = 5000) => {
+  const fetchStats = useCallback(async (knight: string, timeoutMs = SESSION_TIMEOUT_MS) => {
     setLoading(true)
     setError(null)
     try {
@@ -95,7 +99,7 @@ export function useKnightSession() {
     }
   }, [])
 
-  const fetchRecent = useCallback(async (knight: string, limit = 20, timeoutMs = 5000) => {
+  const fetchRecent = useCallback(async (knight: string, limit = 20, timeoutMs = SESSION_TIMEOUT_MS) => {
     try {
       const res = await fetchWithTimeout(`/api/fleet/${knight}/session?type=recent&limit=${limit}`, timeoutMs)
       if (!res || !res.ok) {
@@ -110,7 +114,7 @@ export function useKnightSession() {
     }
   }, [])
 
-  const fetchTree = useCallback(async (knight: string, timeoutMs = 5000) => {
+  const fetchTree = useCallback(async (knight: string, timeoutMs = SESSION_TIMEOUT_MS) => {
     try {
       const res = await fetchWithTimeout(`/api/fleet/${knight}/session?type=tree`, timeoutMs)
       if (!res || !res.ok) {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { Crown, Activity, DollarSign, Zap, AlertTriangle, Link2, ArrowRight, TrendingUp, Calendar, BarChart3, ChevronDown, ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useFleet } from '../hooks/useFleet'
+import { fetchWithTimeout } from '../hooks/useKnightSession'
 import { useWebSocket } from '../hooks/useWebSocket'
 import { getKnightConfig, knightNameForDomain, KNIGHT_NAMES } from '../lib/knights'
 
@@ -51,7 +52,10 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
 
         const results = await Promise.allSettled(
           names.map(name =>
-            fetch(`/api/fleet/${name}/session?type=stats`).then(r => r.json())
+            fetchWithTimeout(`/api/fleet/${name}/session?type=stats`).then(r => {
+              if (!r || !r.ok) throw new Error('introspect unavailable')
+              return r.json()
+            })
           )
         )
 

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { TreePine, ChevronRight, ChevronDown, Wrench, MessageSquare, Brain, RefreshCw, Search, BarChart3, Loader2 } from 'lucide-react'
 import { getKnightConfig, buildKnightConfigFromFleet } from '../lib/knights'
 import { useFleet } from '../hooks/useFleet'
+import { fetchWithTimeout } from '../hooks/useKnightSession'
 import type { SessionEntry, SessionTreeNode, KnightSessionStats } from '../hooks/useKnightSession'
 
 const entryTypeIcons: Record<string, string> = {
@@ -146,15 +147,10 @@ export function SessionsPage() {
     setError(null)
     
     try {
-      // Fetch with timeout - gracefully handle unsupported knights
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
-
-      // Always fetch stats
-      fetch(`/api/fleet/${selectedKnight}/session?type=stats`, { signal: controller.signal })
-        .then(r => r.ok ? r.json() : null)
-        .then(d => { 
-          clearTimeout(timeout)
+      // Always fetch stats (independent request with its own timeout)
+      fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=stats`)
+        .then(r => r && r.ok ? r.json() : null)
+        .then(d => {
           if (d) {
             setStats({ ...d, supported: true })
           } else {
@@ -162,21 +158,20 @@ export function SessionsPage() {
           }
         })
         .catch(() => {
-          clearTimeout(timeout)
           setStats({ knight: selectedKnight, supported: false, session: null, runtime: { uptime: 0, activeTasks: 0, model: '' } })
         })
 
       if (view === 'tree') {
-        const res = await fetch(`/api/fleet/${selectedKnight}/session?type=tree`, { signal: controller.signal })
-        if (!res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=tree`)
+        if (!res || !res.ok) {
           setTreeNodes([])
           return
         }
         const data = await res.json()
         setTreeNodes(data.nodes || [])
       } else {
-        const res = await fetch(`/api/fleet/${selectedKnight}/session?type=recent&limit=100`, { signal: controller.signal })
-        if (!res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=recent&limit=100`)
+        if (!res || !res.ok) {
           setEntries([])
           return
         }
@@ -184,14 +179,7 @@ export function SessionsPage() {
         setEntries(data.entries || [])
       }
     } catch (e) {
-      if ((e as Error).name === 'AbortError') {
-        // Timeout - knight doesn't support introspect
-        setError(null)
-        setEntries([])
-        setTreeNodes([])
-      } else {
-        setError(e instanceof Error ? e.message : 'Failed to fetch session data')
-      }
+      setError(e instanceof Error ? e.message : 'Failed to fetch session data')
     } finally {
       setLoading(false)
     }
@@ -205,11 +193,8 @@ export function SessionsPage() {
     const results: Record<string, KnightSessionStats> = {}
     await Promise.all(knights.map(async k => {
       try {
-        const controller = new AbortController()
-        const timeout = setTimeout(() => controller.abort(), 5000)
-        const res = await fetch(`/api/fleet/${k.name}/session?type=stats`, { signal: controller.signal })
-        clearTimeout(timeout)
-        if (res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${k.name}/session?type=stats`)
+        if (res && res.ok) {
           const data = await res.json()
           results[k.name] = { ...data, supported: true }
         }


### PR DESCRIPTION
Closes #124. Stacked on #129 (test build fix) — merge that first; this PR's base is `fix/go-test-build`.

## Problem

Knight session/introspect stats were flaky or silently empty (details in #124):

1. **Auth bypass**: `Sessions.tsx` (4 calls) and `Dashboard.tsx` used bare `fetch()` with no Authorization header — with `DASHBOARD_API_KEY` set, every introspect call 401'd, all knights showed "unsupported", and Dashboard session costs were silently $0.
2. **Timeout race**: client aborted at exactly 5s, racing the API's 5s NATS introspect timeout — slow knights flapped between supported/unsupported.
3. **Dropped limit**: `?limit=100` was never forwarded; pi-knight's `req.limit ?? 20` default always won.

## Changes

- `useKnightSession` exports an authenticated `fetchWithTimeout` with `SESSION_TIMEOUT_MS = 8000` (above the server's 5s NATS timeout); all its fetchers use it
- `Sessions.tsx` reuses that helper instead of duplicating bare-fetch logic; each request now gets its own timeout (previously stats and tree/recent shared one AbortController whose timer was cleared by whichever finished first)
- `Dashboard.tsx` session-cost sweep uses the authenticated helper and skips non-OK responses
- `knightSessionHandler` forwards a validated `limit` (1–500) in the introspect payload — pi-knight already honors it

## Testing

- `go test ./...` + `go vet` clean
- `npm run build` passes; vitest unchanged (14 pre-existing failures on main, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)