### PR TITLE
fix: knight detail no longer shadows CRD phase, prefers ready pod

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -356,6 +356,11 @@ func main() {
 	}
 }
 
+// podIsReady reports whether the pod's first container is ready.
+func podIsReady(pod *corev1.Pod) bool {
+	return len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready
+}
+
 func buildKnightStatus(cr *unstructured.Unstructured, pod *corev1.Pod) KnightStatus {
 	spec := getNestedMap(cr.Object, "spec")
 	status := getNestedMap(cr.Object, "status")
@@ -451,15 +456,7 @@ func fleetHandler(namespace string) http.HandlerFunc {
 						continue
 					}
 					if existing, exists := podByName[instName]; exists {
-						var existingReady bool
-						if len(existing.Status.ContainerStatuses) > 0 {
-							existingReady = existing.Status.ContainerStatuses[0].Ready
-						}
-						var newReady bool
-						if len(pod.Status.ContainerStatuses) > 0 {
-							newReady = pod.Status.ContainerStatuses[0].Ready
-						}
-						if newReady && !existingReady {
+						if podIsReady(&pod) && !podIsReady(&existing) {
 							podByName[instName] = pod
 						}
 					} else {
@@ -487,9 +484,12 @@ func fleetHandler(namespace string) http.HandlerFunc {
 // KnightDetail is a safe DTO — no raw K8s pod data exposed (#46)
 type KnightDetail struct {
 	KnightStatus
-	Node            string           `json:"node"`
-	PodName         string           `json:"podName"`
-	Phase           string           `json:"phase"`
+	Node    string `json:"node"`
+	PodName string `json:"podName"`
+	// PodPhase is the pod lifecycle phase (Running/Pending/...). Deliberately
+	// NOT named Phase: that would shadow the embedded CRD phase (Ready/
+	// Degraded/...) in the JSON output (#125)
+	PodPhase        string           `json:"podPhase,omitempty"`
 	StartTime       *time.Time       `json:"startTime"`
 	Containers      []ContainerDetail `json:"containers"`
 	Conditions      []PodCondition   `json:"conditions"`
@@ -532,14 +532,19 @@ func knightHandler(namespace string) http.HandlerFunc {
 			return
 		}
 
-		// Find matching pod (best-effort; knight may not have a pod yet)
+		// Find matching pod (best-effort; knight may not have a pod yet).
+		// Prefer the ready pod so rollouts show the new pod, matching fleetHandler.
 		var podPtr *corev1.Pod
 		if k8sClient != nil {
 			pods, podErr := k8sClient.CoreV1().Pods(namespace).List(r.Context(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("app.kubernetes.io/name=knight,app.kubernetes.io/instance=%s", name),
 			})
-			if podErr == nil && len(pods.Items) > 0 {
-				podPtr = &pods.Items[0]
+			if podErr == nil {
+				for i := range pods.Items {
+					if podPtr == nil || (!podIsReady(podPtr) && podIsReady(&pods.Items[i])) {
+						podPtr = &pods.Items[i]
+					}
+				}
 			}
 		}
 
@@ -551,7 +556,7 @@ func knightHandler(namespace string) http.HandlerFunc {
 			pod := podPtr
 			detail.Node = pod.Spec.NodeName
 			detail.PodName = pod.Name
-			detail.Phase = string(pod.Status.Phase)
+			detail.PodPhase = string(pod.Status.Phase)
 			if !pod.CreationTimestamp.IsZero() {
 				t := pod.CreationTimestamp.Time
 				detail.StartTime = &t

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -359,6 +359,29 @@ func TestKnightHandler(t *testing.T) {
 		t.Fatalf("failed to create knight CR: %v", err)
 	}
 
+	// Terminating pod from an old ReplicaSet — sorts before the ready pod by
+	// name; the handler must prefer the ready one (#125)
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tristan-abc123",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "knight",
+				"app.kubernetes.io/instance": "tristan",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "knight", Image: "knight:v0"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "knight", Ready: false},
+			},
+		},
+	}
+	fakeK8sClient.CoreV1().Pods(namespace).Create(nil, oldPod, metav1.CreateOptions{})
+
 	tests := []struct {
 		name           string
 		knightName     string
@@ -380,8 +403,18 @@ func TestKnightHandler(t *testing.T) {
 				if detail.Node != "node-1" {
 					t.Errorf("expected node 'node-1', got '%s'", detail.Node)
 				}
-				if detail.Phase != "Running" {
-					t.Errorf("expected phase 'Running', got '%s'", detail.Phase)
+				if detail.PodName != "tristan-xyz789" {
+					t.Errorf("expected ready pod 'tristan-xyz789', got '%s'", detail.PodName)
+				}
+				if detail.PodPhase != "Running" {
+					t.Errorf("expected podPhase 'Running', got '%s'", detail.PodPhase)
+				}
+				// The JSON phase key must carry the CRD phase, not the pod
+				// phase — KnightDetail.PodPhase must not shadow it (#125)
+				var raw map[string]interface{}
+				json.Unmarshal(body, &raw)
+				if raw["phase"] != "Ready" {
+					t.Errorf("expected JSON phase 'Ready' (CRD phase), got '%v'", raw["phase"])
 				}
 			},
 		},


### PR DESCRIPTION
Closes #125. Stacked on #129 (test build fix) — merge that first; this PR's base is `fix/go-test-build`.

## Problem

1. `KnightDetail` embedded `KnightStatus` (whose `Phase` is the CRD phase, e.g. `Ready`/`Degraded`) but declared its own `Phase` set to the **pod** phase (`Running`). The outer field shadows the embedded one in JSON, so `/api/fleet` and `/api/fleet/{knight}` reported different values under the same `phase` key.
2. `knightHandler` used `pods.Items[0]` while `fleetHandler` preferred the ready pod — during rollouts the detail page could show the old terminating pod's image/restarts/status.

## Changes

- Pod lifecycle phase renamed to `podPhase` (new JSON key); `phase` now consistently carries the CRD phase on both endpoints. No UI component read the detail `phase`, so nothing breaks client-side.
- Extracted `podIsReady` helper; both handlers now prefer the ready pod.

## Testing

- `TestKnightHandler` now asserts the JSON `phase` key carries the CRD phase, `podPhase` carries the pod phase, and that a not-ready old-ReplicaSet pod (sorting first by name) loses to the ready pod
- `go test ./...` + `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)