### PR TITLE
fix: stop double-counting costs on the dashboard

### DIFF
--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -92,12 +92,18 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
       if (knight) knightCosts[knight] = (knightCosts[knight] || 0) + cost
     }
 
-    // Merge cumulative session costs (primary) with live WS costs (supplementary)
+    // Session introspection cost is cumulative and already includes any task
+    // that also arrived as a live result event — adding both double-counts.
+    // Session cost is authoritative per knight; live WS costs only fill in
+    // for knights that didn't report session stats.
     const mergedCosts: Record<string, number> = { ...sessionCosts.perKnight }
+    let mergedTotal = sessionCosts.total
     for (const [name, cost] of Object.entries(knightCosts)) {
-      mergedCosts[name] = (mergedCosts[name] || 0) + cost
+      if (!(name in mergedCosts)) {
+        mergedCosts[name] = cost
+        mergedTotal += cost
+      }
     }
-    const mergedTotal = sessionCosts.total + totalCost
 
     const topKnights = Object.entries(mergedCosts)
       .sort((a, b) => b[1] - a[1])


### PR DESCRIPTION
Closes #126. Stacked on #131 (result parsing) — merge that first; this PR's base is `fix/result-subject-parsing`.

## Problem

`Dashboard.tsx` merged per-knight costs as cumulative session cost (from knight introspection, which already includes all completed tasks) **plus** live WebSocket result costs — any task completing while the dashboard was open was counted twice, inflating "Session Cost" and the top-knights ranking.

## Change

Session introspection cost is now authoritative for knights that report it; live WS costs are only used for knights without session stats (e.g. introspection unsupported or down).

## Testing

`npm run build` passes; behavior verified by inspection of the merge logic (the inputs overlap by construction, so summing both is provably wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)