### PR TITLE
fix: share one WebSocket connection app-wide via context

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,7 +15,7 @@ import { LoginPage } from './pages/Login'
 import { RoundTablesPage } from './pages/RoundTables'
 import { ToastProvider, useToast } from './components/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
-import { useWebSocket } from './hooks/useWebSocket'
+import { useWebSocket, WebSocketProvider } from './hooks/useWebSocket'
 import { useTaskNotifications } from './hooks/useTaskNotifications'
 import { isAuthenticated, clearApiKey } from './lib/auth'
 
@@ -99,6 +99,7 @@ export default function App() {
   }
 
   return (
+    <WebSocketProvider>
     <ToastProvider>
     <div className="flex h-screen">
       <NotificationWatcher />
@@ -187,5 +188,6 @@ export default function App() {
       </main>
     </div>
     </ToastProvider>
+    </WebSocketProvider>
   )
 }

--- a/ui/src/hooks/useWebSocket.tsx
+++ b/ui/src/hooks/useWebSocket.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, createContext, useContext, type ReactNode } from 'react'
 import { getApiKey, authFetch } from '../lib/auth'
 
 export interface NatsEvent {
@@ -24,7 +24,12 @@ export function eventKey(e: NatsEvent): string {
   return `${e.subject}:${e.timestamp}`
 }
 
-export function useWebSocket() {
+/**
+ * Owns a WebSocket connection + event feed. Use via WebSocketProvider /
+ * useWebSocket — mounting this hook directly opens a NEW connection
+ * (4 NATS subscriptions server-side) and refetches history.
+ */
+function useWebSocketConnection() {
   const [events, setEvents] = useState<NatsEvent[]>([])
   const [connected, setConnected] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -151,4 +156,26 @@ export function useWebSocket() {
   }, [])
 
   return { events, connected, error, dispatch, clearEvents }
+}
+
+type WebSocketState = ReturnType<typeof useWebSocketConnection>
+
+const WebSocketContext = createContext<WebSocketState | null>(null)
+
+/**
+ * Holds the app's single WebSocket connection and event feed (#127).
+ * Mount once near the root; every useWebSocket() consumer shares it.
+ */
+export function WebSocketProvider({ children }: { children: ReactNode }) {
+  const ws = useWebSocketConnection()
+  return <WebSocketContext.Provider value={ws}>{children}</WebSocketContext.Provider>
+}
+
+/** Access the shared WebSocket event feed. Requires WebSocketProvider. */
+export function useWebSocket(): WebSocketState {
+  const ctx = useContext(WebSocketContext)
+  if (!ctx) {
+    throw new Error('useWebSocket must be used within a WebSocketProvider')
+  }
+  return ctx
 }


### PR DESCRIPTION
Closes #127. Stacked on #132 (notification tracking) — merge that first; this PR's base is `fix/notification-tracking`.

## Problem

`useWebSocket()` was instantiated independently in `App.tsx` (NotificationWatcher), `Dashboard.tsx`, `Fleet.tsx`, and `Live.tsx`. Each instance opened its own `/api/ws` socket — 4 NATS subscriptions server-side apiece — and refetched `/api/tasks` history on every mount. Two to three concurrent sockets per tab, duplicated event streams that could disagree, and inconsistent "connected" indicators.

## Changes

- Connection logic moved into a private `useWebSocketConnection`
- New `WebSocketProvider` mounts it once at the app root; `useWebSocket()` now consumes the shared context, so existing call sites are unchanged
- File renamed `useWebSocket.ts` → `.tsx` (provider JSX); import paths unaffected

## Testing

`npm run build` passes; vitest unchanged (existing mocks of the hook still apply; 14 pre-existing failures on main tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)