### PR TITLE
chore: minor API and type cleanups from codebase review

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -174,7 +174,8 @@ func authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// rateLimiter is a simple sliding-window rate limiter (#12)
+// rateLimiterT is a simple fixed-window rate limiter (#12): the token bucket
+// refills in full every interval. Note it is global — shared by all clients.
 type rateLimiterT struct {
 	mu       sync.Mutex
 	tokens   int
@@ -1443,7 +1444,14 @@ func missionCreateHandler(namespace string) http.HandlerFunc {
 			}
 		}
 
-		// Build mission object
+		// Build mission object — copy the request body into spec without the
+		// metadata-level name key (it is not a spec field)
+		spec := make(map[string]interface{}, len(reqBody))
+		for k, v := range reqBody {
+			if k != "name" {
+				spec[k] = v
+			}
+		}
 		mission := map[string]interface{}{
 			"apiVersion": "ai.roundtable.io/v1alpha1",
 			"kind":       "Mission",
@@ -1451,7 +1459,7 @@ func missionCreateHandler(namespace string) http.HandlerFunc {
 				"name":      name,
 				"namespace": namespace,
 			},
-			"spec": reqBody,
+			"spec": spec,
 		}
 
 		// Create via dynamic client

--- a/ui/src/components/KnightDetailDrawer.tsx
+++ b/ui/src/components/KnightDetailDrawer.tsx
@@ -93,7 +93,7 @@ export function KnightDetailDrawer({ knight, onClose }: Props) {
   const fetchLogs = async (knightName: string) => {
     setLogsLoading(true)
     try {
-      const res = await fetch(`/api/fleet/${knightName}/logs?tail=100`)
+      const res = await authFetch(`/api/fleet/${knightName}/logs`)
       if (res.ok) {
         const text = await res.text()
         setLogs(text)

--- a/ui/src/hooks/useKnightSession.ts
+++ b/ui/src/hooks/useKnightSession.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import { authFetch } from '../lib/auth'
 
+// Matches pi-knight's introspect stats response (src/introspect.ts buildStats)
 export interface KnightSessionStats {
   knight: string
   supported?: boolean  // whether knight responded to introspect
@@ -9,9 +10,8 @@ export interface KnightSessionStats {
     userMessages: number
     assistantMessages: number
     toolCalls: number
-    toolResults: number
     totalMessages: number
-    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }
+    tokens: { input: number; output: number; total: number }
     cost: number
   } | null
   runtime: {


### PR DESCRIPTION
Closes #128. Stacked on #129 (test build fix) — merge that first; this PR's base is `fix/go-test-build`.

Batched small items from the review:

- **Rate limiter**: comment claimed sliding-window; it's a fixed-window refill. Comment corrected and now documents that the limiter is global (shared by all clients).
- **Mission create**: the whole request body was stored as `spec`, including the metadata-level `name` key; it's now stripped before the CR is built.
- **Type drift**: `KnightSessionStats` declared `tokens.cacheRead`/`cacheWrite`/`toolResults`, none of which pi-knight's `buildStats` actually returns — the type now matches the wire format.
- **Logs fetch**: `KnightDetailDrawer` fetched pod logs with bare `fetch()` (401s when `DASHBOARD_API_KEY` is set — same class of bug as #124) and passed a `tail` param the API never reads. Now `authFetch` without the dead param.

## Testing

`go test ./...` + `go vet` clean; `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)