### PR TITLE
fix: update stale UI tests to current component markup

### DIFF
--- a/ui/src/components/KnightCard.test.tsx
+++ b/ui/src/components/KnightCard.test.tsx
@@ -48,7 +48,8 @@ describe('KnightCard', () => {
 
   it('renders ready state', () => {
     render(<KnightCard knight={mockKnight} />)
-    expect(screen.getByText('Ready')).toBeInTheDocument()
+    // 'Ready' appears in both the readiness cell and the phase badge
+    expect(screen.getAllByText('Ready').length).toBeGreaterThan(0)
   })
 
   it('renders not ready state when knight is not ready', () => {
@@ -225,8 +226,10 @@ describe('KnightCard', () => {
 
   // New CRD parity tests
   it('renders phase badge when phase is provided', () => {
-    render(<KnightCard knight={mockKnight} />)
-    expect(screen.getByText('Ready')).toBeInTheDocument()
+    const { container } = render(<KnightCard knight={mockKnight} />)
+    const badge = container.querySelector('.bg-green-500\\/20')
+    expect(badge).toBeInTheDocument()
+    expect(badge!.textContent).toBe('Ready')
   })
 
   it('renders Degraded phase with yellow styling', () => {
@@ -286,8 +289,9 @@ describe('KnightCard', () => {
   })
 
   it('displays total cost when provided', () => {
+    // totalCost is rendered verbatim from the CRD string
     render(<KnightCard knight={mockKnight} />)
-    expect(screen.getByText(/\$12\.45/)).toBeInTheDocument()
+    expect(screen.getByText('12.45')).toBeInTheDocument()
   })
 
   it('handles knight without optional CRD fields', () => {
@@ -305,7 +309,9 @@ describe('KnightCard', () => {
     }
     
     render(<KnightCard knight={minimalKnight} />)
-    expect(screen.getByText('minimal')).toBeInTheDocument()
+    // Unknown knights fall back to a config title equal to the name,
+    // so 'minimal' renders twice (name + title)
+    expect(screen.getAllByText('minimal').length).toBeGreaterThan(0)
     expect(screen.queryByText('SUSPENDED')).not.toBeInTheDocument()
   })
 })

--- a/ui/src/pages/Dashboard.test.tsx
+++ b/ui/src/pages/Dashboard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import { DashboardPage } from './Dashboard'
+import { useFleet } from '../hooks/useFleet'
 
 // Mock the hooks
 vi.mock('../hooks/useFleet', () => ({
@@ -88,7 +89,7 @@ describe('DashboardPage', () => {
 
   it('renders the dashboard title', () => {
     renderDashboard()
-    expect(screen.getByText('Round Table Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Command Center')).toBeInTheDocument()
   })
 
   it('displays fleet status section', async () => {
@@ -101,7 +102,7 @@ describe('DashboardPage', () => {
   it('shows online knight count', async () => {
     renderDashboard()
     await waitFor(() => {
-      expect(screen.getByText('2')).toBeInTheDocument() // 2 knights online
+      expect(screen.getByText('2/2')).toBeInTheDocument() // 2 of 2 knights online
     })
   })
 
@@ -125,7 +126,7 @@ describe('DashboardPage', () => {
   it('cost panel is expanded when defaultCostExpanded is true', async () => {
     renderDashboard({ defaultCostExpanded: true })
     await waitFor(() => {
-      expect(screen.getByText(/Session Costs/i)).toBeInTheDocument()
+      expect(screen.getByText(/Daily Cost Trend/i)).toBeInTheDocument()
     })
   })
 
@@ -134,71 +135,69 @@ describe('DashboardPage', () => {
     renderDashboard()
 
     // Find and click the cost panel toggle button
-    const costButton = screen.getByRole('button', { name: /Session Costs/i })
-    
+    const costButton = screen.getByRole('button', { name: /Cost Details/i })
+
     // Initially collapsed
-    expect(screen.queryByText(/Per-Knight Breakdown/i)).not.toBeInTheDocument()
-    
+    expect(screen.queryByText(/Daily Cost Trend/i)).not.toBeInTheDocument()
+
     // Click to expand
     await user.click(costButton)
-    
+
     await waitFor(() => {
-      expect(screen.getByText(/Per-Knight Breakdown/i)).toBeInTheDocument()
+      expect(screen.getByText(/Daily Cost Trend/i)).toBeInTheDocument()
     })
-    
+
     // Click to collapse
     await user.click(costButton)
-    
+
     await waitFor(() => {
-      expect(screen.queryByText(/Per-Knight Breakdown/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Daily Cost Trend/i)).not.toBeInTheDocument()
     })
   })
 
   it('displays activity feed section', async () => {
     renderDashboard()
     await waitFor(() => {
-      expect(screen.getByText(/Activity Feed/i)).toBeInTheDocument()
+      expect(screen.getByText(/Recent Activity/i)).toBeInTheDocument()
     })
   })
 
   it('shows recent chains section', async () => {
     renderDashboard()
     await waitFor(() => {
-      expect(screen.getByText(/Recent Chains/i)).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /Chains/i })).toBeInTheDocument()
     })
   })
 
   it('displays WebSocket connection status', async () => {
     renderDashboard()
     await waitFor(() => {
-      // Connected status indicator
-      const liveIndicator = screen.queryByText(/live/i)
-      expect(liveIndicator).toBeInTheDocument()
+      // Connected status indicator in the header
+      expect(screen.queryAllByText(/live/i).length).toBeGreaterThan(0)
     })
   })
 
   it('renders fleet link', () => {
     renderDashboard()
-    const fleetLink = screen.getByRole('link', { name: /View Full Fleet/i })
-    expect(fleetLink).toHaveAttribute('href', '/fleet')
+    const links = screen.getAllByRole('link', { name: /View all/i })
+    expect(links.some(l => l.getAttribute('href') === '/fleet')).toBe(true)
   })
 
   it('renders chains link', () => {
     renderDashboard()
-    const chainsLink = screen.getByRole('link', { name: /View All Chains/i })
-    expect(chainsLink).toHaveAttribute('href', '/chains')
+    const links = screen.getAllByRole('link', { name: /View all/i })
+    expect(links.some(l => l.getAttribute('href') === '/chains')).toBe(true)
   })
 
   it('handles empty fleet gracefully', () => {
-    const { useFleet } = require('../hooks/useFleet')
-    useFleet.mockReturnValueOnce({
+    vi.mocked(useFleet).mockReturnValueOnce({
       knights: [],
       loading: false,
       error: null,
-    })
+    } as unknown as ReturnType<typeof useFleet>)
 
     renderDashboard()
-    expect(screen.getByText('Round Table Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Command Center')).toBeInTheDocument()
   })
 
   it('displays time range selector', async () => {


### PR DESCRIPTION
Closes #138.

## Problem

`npm test` failed on `main` with 14 failures in `KnightCard.test.tsx` (4) and `Dashboard.test.tsx` (10) — tests written against pre-CRD-parity component markup. A broken baseline hides real regressions (same story as the Go suite in #129).

## Changes

Test-only; no component behavior changed:

- **KnightCard**: "Ready" now appears in both the phase badge and readiness cell (use `getAllByText` / badge-class assertions); `totalCost` renders verbatim from the CRD string; unknown knights render their name twice via the config-title fallback
- **Dashboard**: updated to current texts — "Command Center", "Cost Details" / "Daily Cost Trend", "Recent Activity", "View all" links, "2/2" knight metric
- Replaced a CommonJS `require()` (throws under ESM vitest) with `vi.mocked()`

## Testing

`npm test`: **74/74 pass** (was 60/74). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)