### PR TITLE
fix: promote stranded stack changes — task history, session stats, knight phase, cleanups

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -109,6 +109,20 @@ type TaskEvent struct {
 	Timestamp time.Time       `json:"timestamp"`
 }
 
+// eventTimestamp extracts the producer timestamp from an event payload so the
+// same message gets the same timestamp whether it arrives live over the
+// WebSocket or is replayed from JetStream history — the frontend dedup key is
+// subject+timestamp. Falls back to now for payloads without a timestamp.
+func eventTimestamp(data []byte) time.Time {
+	var payload struct {
+		Timestamp time.Time `json:"timestamp"`
+	}
+	if err := json.Unmarshal(data, &payload); err == nil && !payload.Timestamp.IsZero() {
+		return payload.Timestamp
+	}
+	return time.Now()
+}
+
 // validK8sName validates Kubernetes resource names to prevent label selector injection.
 var validK8sName = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
@@ -705,14 +719,25 @@ func taskHistoryHandler(fleetPrefix, streamName string) http.HandlerFunc {
 			return
 		}
 
-		info, _ := stream.Info(ctx)
+		info, err := stream.Info(ctx)
+		if err != nil {
+			log.Printf("JetStream stream info error: %v", err)
+			http.Error(w, "Task history unavailable", http.StatusInternalServerError)
+			return
+		}
 		results := []TaskEvent{}
 
-		// Get last N messages
-		limit := 50
-		// Use a named ephemeral consumer with InactiveThreshold for auto-cleanup (#54)
+		// Get the newest N messages: result subjects are unique per task, so
+		// start limit messages back from the stream tail and read forward
+		const limit = 50
+		startSeq := uint64(1)
+		if info.State.LastSeq > limit {
+			startSeq = info.State.LastSeq - limit + 1
+		}
+		// Ephemeral consumer with InactiveThreshold for auto-cleanup (#54)
 		cons, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-			DeliverPolicy:     jetstream.DeliverLastPerSubjectPolicy,
+			DeliverPolicy:     jetstream.DeliverByStartSequencePolicy,
+			OptStartSeq:       startSeq,
 			FilterSubject:     fleetPrefix + ".results.>",
 			AckPolicy:         jetstream.AckNonePolicy,
 			InactiveThreshold: 30 * time.Second,
@@ -727,14 +752,14 @@ func taskHistoryHandler(fleetPrefix, streamName string) http.HandlerFunc {
 			return
 		}
 
-		msgs, _ := cons.Fetch(limit, jetstream.FetchMaxWait(5*time.Second))
+		msgs, _ := cons.FetchNoWait(limit)
 		if msgs != nil {
 			for msg := range msgs.Messages() {
 				results = append(results, TaskEvent{
 					Type:      "result",
 					Subject:   msg.Subject(),
 					Data:      msg.Data(),
-					Timestamp: time.Now(),
+					Timestamp: eventTimestamp(msg.Data()),
 				})
 			}
 		}
@@ -899,7 +924,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "task",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -920,7 +945,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "result",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -943,7 +968,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "mission",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)
@@ -965,7 +990,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 				Type:      "chain",
 				Subject:   msg.Subject,
 				Data:      msg.Data,
-				Timestamp: time.Now(),
+				Timestamp: eventTimestamp(msg.Data),
 			}
 			data, _ := json.Marshal(event)
 			safeWrite(data)

--- a/api/main.go
+++ b/api/main.go
@@ -356,6 +356,11 @@ func main() {
 	}
 }
 
+// podIsReady reports whether the pod's first container is ready.
+func podIsReady(pod *corev1.Pod) bool {
+	return len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready
+}
+
 func buildKnightStatus(cr *unstructured.Unstructured, pod *corev1.Pod) KnightStatus {
 	spec := getNestedMap(cr.Object, "spec")
 	status := getNestedMap(cr.Object, "status")
@@ -451,15 +456,7 @@ func fleetHandler(namespace string) http.HandlerFunc {
 						continue
 					}
 					if existing, exists := podByName[instName]; exists {
-						var existingReady bool
-						if len(existing.Status.ContainerStatuses) > 0 {
-							existingReady = existing.Status.ContainerStatuses[0].Ready
-						}
-						var newReady bool
-						if len(pod.Status.ContainerStatuses) > 0 {
-							newReady = pod.Status.ContainerStatuses[0].Ready
-						}
-						if newReady && !existingReady {
+						if podIsReady(&pod) && !podIsReady(&existing) {
 							podByName[instName] = pod
 						}
 					} else {
@@ -487,9 +484,12 @@ func fleetHandler(namespace string) http.HandlerFunc {
 // KnightDetail is a safe DTO — no raw K8s pod data exposed (#46)
 type KnightDetail struct {
 	KnightStatus
-	Node            string           `json:"node"`
-	PodName         string           `json:"podName"`
-	Phase           string           `json:"phase"`
+	Node    string `json:"node"`
+	PodName string `json:"podName"`
+	// PodPhase is the pod lifecycle phase (Running/Pending/...). Deliberately
+	// NOT named Phase: that would shadow the embedded CRD phase (Ready/
+	// Degraded/...) in the JSON output (#125)
+	PodPhase        string           `json:"podPhase,omitempty"`
 	StartTime       *time.Time       `json:"startTime"`
 	Containers      []ContainerDetail `json:"containers"`
 	Conditions      []PodCondition   `json:"conditions"`
@@ -532,14 +532,19 @@ func knightHandler(namespace string) http.HandlerFunc {
 			return
 		}
 
-		// Find matching pod (best-effort; knight may not have a pod yet)
+		// Find matching pod (best-effort; knight may not have a pod yet).
+		// Prefer the ready pod so rollouts show the new pod, matching fleetHandler.
 		var podPtr *corev1.Pod
 		if k8sClient != nil {
 			pods, podErr := k8sClient.CoreV1().Pods(namespace).List(r.Context(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("app.kubernetes.io/name=knight,app.kubernetes.io/instance=%s", name),
 			})
-			if podErr == nil && len(pods.Items) > 0 {
-				podPtr = &pods.Items[0]
+			if podErr == nil {
+				for i := range pods.Items {
+					if podPtr == nil || (!podIsReady(podPtr) && podIsReady(&pods.Items[i])) {
+						podPtr = &pods.Items[i]
+					}
+				}
 			}
 		}
 
@@ -551,7 +556,7 @@ func knightHandler(namespace string) http.HandlerFunc {
 			pod := podPtr
 			detail.Node = pod.Spec.NodeName
 			detail.PodName = pod.Name
-			detail.Phase = string(pod.Status.Phase)
+			detail.PodPhase = string(pod.Status.Phase)
 			if !pod.CreationTimestamp.IsZero() {
 				t := pod.CreationTimestamp.Time
 				detail.StartTime = &t

--- a/api/main.go
+++ b/api/main.go
@@ -174,7 +174,8 @@ func authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// rateLimiter is a simple sliding-window rate limiter (#12)
+// rateLimiterT is a simple fixed-window rate limiter (#12): the token bucket
+// refills in full every interval. Note it is global — shared by all clients.
 type rateLimiterT struct {
 	mu       sync.Mutex
 	tokens   int
@@ -1443,7 +1444,14 @@ func missionCreateHandler(namespace string) http.HandlerFunc {
 			}
 		}
 
-		// Build mission object
+		// Build mission object — copy the request body into spec without the
+		// metadata-level name key (it is not a spec field)
+		spec := make(map[string]interface{}, len(reqBody))
+		for k, v := range reqBody {
+			if k != "name" {
+				spec[k] = v
+			}
+		}
 		mission := map[string]interface{}{
 			"apiVersion": "ai.roundtable.io/v1alpha1",
 			"kind":       "Mission",
@@ -1451,7 +1459,7 @@ func missionCreateHandler(namespace string) http.HandlerFunc {
 				"name":      name,
 				"namespace": namespace,
 			},
-			"spec": reqBody,
+			"spec": spec,
 		}
 
 		// Create via dynamic client

--- a/api/main.go
+++ b/api/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -678,11 +679,19 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
+		// Forward a validated entry limit (pi-knight defaults to 20 for type=recent)
+		introspectReq := map[string]interface{}{"type": reqType}
+		if limStr := r.URL.Query().Get("limit"); limStr != "" {
+			if lim, limErr := strconv.Atoi(limStr); limErr == nil && lim > 0 && lim <= 500 {
+				introspectReq["limit"] = lim
+			}
+		}
+		payload, _ := json.Marshal(introspectReq)
+
 		// Knight names in NATS are capitalized (e.g., "Galahad")
 		capitalName := capitalizeKnight(name)
 		subject := fmt.Sprintf("%s.introspect.%s", fleetPrefix, capitalName)
-		payload := fmt.Sprintf(`{"type":"%s"}`, reqType)
-		msg, err := nc.Request(subject, []byte(payload), 5*time.Second)
+		msg, err := nc.Request(subject, payload, 5*time.Second)
 		if err != nil {
 			log.Printf("Knight introspect timeout for %s: %v", name, err)
 			http.Error(w, "Knight introspection timeout", http.StatusGatewayTimeout)

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -359,6 +359,29 @@ func TestKnightHandler(t *testing.T) {
 		t.Fatalf("failed to create knight CR: %v", err)
 	}
 
+	// Terminating pod from an old ReplicaSet — sorts before the ready pod by
+	// name; the handler must prefer the ready one (#125)
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tristan-abc123",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "knight",
+				"app.kubernetes.io/instance": "tristan",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "knight", Image: "knight:v0"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "knight", Ready: false},
+			},
+		},
+	}
+	fakeK8sClient.CoreV1().Pods(namespace).Create(nil, oldPod, metav1.CreateOptions{})
+
 	tests := []struct {
 		name           string
 		knightName     string
@@ -380,8 +403,18 @@ func TestKnightHandler(t *testing.T) {
 				if detail.Node != "node-1" {
 					t.Errorf("expected node 'node-1', got '%s'", detail.Node)
 				}
-				if detail.Phase != "Running" {
-					t.Errorf("expected phase 'Running', got '%s'", detail.Phase)
+				if detail.PodName != "tristan-xyz789" {
+					t.Errorf("expected ready pod 'tristan-xyz789', got '%s'", detail.PodName)
+				}
+				if detail.PodPhase != "Running" {
+					t.Errorf("expected podPhase 'Running', got '%s'", detail.PodPhase)
+				}
+				// The JSON phase key must carry the CRD phase, not the pod
+				// phase — KnightDetail.PodPhase must not shadow it (#125)
+				var raw map[string]interface{}
+				json.Unmarshal(body, &raw)
+				if raw["phase"] != "Ready" {
+					t.Errorf("expected JSON phase 'Ready' (CRD phase), got '%v'", raw["phase"])
 				}
 			},
 		},

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -937,6 +937,28 @@ func TestCapitalizeKnight(t *testing.T) {
 	}
 }
 
+// TestEventTimestamp tests payload timestamp extraction for event dedup
+func TestEventTimestamp(t *testing.T) {
+	want := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
+	payload := []byte(`{"task_id":"galahad-ui-1","success":true,"timestamp":"2026-06-01T12:30:00Z"}`)
+	if got := eventTimestamp(payload); !got.Equal(want) {
+		t.Errorf("eventTimestamp = %v, expected %v", got, want)
+	}
+
+	// Missing / invalid timestamps fall back to roughly now
+	for _, data := range [][]byte{
+		[]byte(`{"task_id":"x"}`),
+		[]byte(`{"timestamp":"not-a-time"}`),
+		[]byte(`not json`),
+		nil,
+	} {
+		got := eventTimestamp(data)
+		if time.Since(got) > time.Minute || time.Until(got) > time.Minute {
+			t.Errorf("eventTimestamp(%q) = %v, expected approximately now", data, got)
+		}
+	}
+}
+
 // TestEnvOr tests the environment variable helper
 func TestEnvOr(t *testing.T) {
 	os.Setenv("TEST_VAR", "value")

--- a/ui/src/components/KnightDetailDrawer.tsx
+++ b/ui/src/components/KnightDetailDrawer.tsx
@@ -93,7 +93,7 @@ export function KnightDetailDrawer({ knight, onClose }: Props) {
   const fetchLogs = async (knightName: string) => {
     setLogsLoading(true)
     try {
-      const res = await fetch(`/api/fleet/${knightName}/logs?tail=100`)
+      const res = await authFetch(`/api/fleet/${knightName}/logs`)
       if (res.ok) {
         const text = await res.text()
         setLogs(text)

--- a/ui/src/hooks/useKnightSession.ts
+++ b/ui/src/hooks/useKnightSession.ts
@@ -45,8 +45,12 @@ export interface SessionTreeNode {
   summary: string
 }
 
+// Client-side timeout must exceed the API's 5s NATS introspect timeout —
+// otherwise the client aborts first and a slow knight looks "unsupported"
+export const SESSION_TIMEOUT_MS = 8000
+
 // Helper to add timeout to fetch requests
-async function fetchWithTimeout(url: string, timeoutMs = 5000): Promise<Response | null> {
+export async function fetchWithTimeout(url: string, timeoutMs = SESSION_TIMEOUT_MS): Promise<Response | null> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   
@@ -70,7 +74,7 @@ export function useKnightSession() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchStats = useCallback(async (knight: string, timeoutMs = 5000) => {
+  const fetchStats = useCallback(async (knight: string, timeoutMs = SESSION_TIMEOUT_MS) => {
     setLoading(true)
     setError(null)
     try {
@@ -95,7 +99,7 @@ export function useKnightSession() {
     }
   }, [])
 
-  const fetchRecent = useCallback(async (knight: string, limit = 20, timeoutMs = 5000) => {
+  const fetchRecent = useCallback(async (knight: string, limit = 20, timeoutMs = SESSION_TIMEOUT_MS) => {
     try {
       const res = await fetchWithTimeout(`/api/fleet/${knight}/session?type=recent&limit=${limit}`, timeoutMs)
       if (!res || !res.ok) {
@@ -110,7 +114,7 @@ export function useKnightSession() {
     }
   }, [])
 
-  const fetchTree = useCallback(async (knight: string, timeoutMs = 5000) => {
+  const fetchTree = useCallback(async (knight: string, timeoutMs = SESSION_TIMEOUT_MS) => {
     try {
       const res = await fetchWithTimeout(`/api/fleet/${knight}/session?type=tree`, timeoutMs)
       if (!res || !res.ok) {

--- a/ui/src/hooks/useKnightSession.ts
+++ b/ui/src/hooks/useKnightSession.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import { authFetch } from '../lib/auth'
 
+// Matches pi-knight's introspect stats response (src/introspect.ts buildStats)
 export interface KnightSessionStats {
   knight: string
   supported?: boolean  // whether knight responded to introspect
@@ -9,9 +10,8 @@ export interface KnightSessionStats {
     userMessages: number
     assistantMessages: number
     toolCalls: number
-    toolResults: number
     totalMessages: number
-    tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }
+    tokens: { input: number; output: number; total: number }
     cost: number
   } | null
   runtime: {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { Crown, Activity, DollarSign, Zap, AlertTriangle, Link2, ArrowRight, TrendingUp, Calendar, BarChart3, ChevronDown, ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useFleet } from '../hooks/useFleet'
+import { fetchWithTimeout } from '../hooks/useKnightSession'
 import { useWebSocket } from '../hooks/useWebSocket'
 import { getKnightConfig, knightNameForDomain, KNIGHT_NAMES } from '../lib/knights'
 
@@ -51,7 +52,10 @@ export function DashboardPage({ defaultCostExpanded = false }: { defaultCostExpa
 
         const results = await Promise.allSettled(
           names.map(name =>
-            fetch(`/api/fleet/${name}/session?type=stats`).then(r => r.json())
+            fetchWithTimeout(`/api/fleet/${name}/session?type=stats`).then(r => {
+              if (!r || !r.ok) throw new Error('introspect unavailable')
+              return r.json()
+            })
           )
         )
 

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { TreePine, ChevronRight, ChevronDown, Wrench, MessageSquare, Brain, RefreshCw, Search, BarChart3, Loader2 } from 'lucide-react'
 import { getKnightConfig, buildKnightConfigFromFleet } from '../lib/knights'
 import { useFleet } from '../hooks/useFleet'
+import { fetchWithTimeout } from '../hooks/useKnightSession'
 import type { SessionEntry, SessionTreeNode, KnightSessionStats } from '../hooks/useKnightSession'
 
 const entryTypeIcons: Record<string, string> = {
@@ -146,15 +147,10 @@ export function SessionsPage() {
     setError(null)
     
     try {
-      // Fetch with timeout - gracefully handle unsupported knights
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
-
-      // Always fetch stats
-      fetch(`/api/fleet/${selectedKnight}/session?type=stats`, { signal: controller.signal })
-        .then(r => r.ok ? r.json() : null)
-        .then(d => { 
-          clearTimeout(timeout)
+      // Always fetch stats (independent request with its own timeout)
+      fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=stats`)
+        .then(r => r && r.ok ? r.json() : null)
+        .then(d => {
           if (d) {
             setStats({ ...d, supported: true })
           } else {
@@ -162,21 +158,20 @@ export function SessionsPage() {
           }
         })
         .catch(() => {
-          clearTimeout(timeout)
           setStats({ knight: selectedKnight, supported: false, session: null, runtime: { uptime: 0, activeTasks: 0, model: '' } })
         })
 
       if (view === 'tree') {
-        const res = await fetch(`/api/fleet/${selectedKnight}/session?type=tree`, { signal: controller.signal })
-        if (!res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=tree`)
+        if (!res || !res.ok) {
           setTreeNodes([])
           return
         }
         const data = await res.json()
         setTreeNodes(data.nodes || [])
       } else {
-        const res = await fetch(`/api/fleet/${selectedKnight}/session?type=recent&limit=100`, { signal: controller.signal })
-        if (!res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${selectedKnight}/session?type=recent&limit=100`)
+        if (!res || !res.ok) {
           setEntries([])
           return
         }
@@ -184,14 +179,7 @@ export function SessionsPage() {
         setEntries(data.entries || [])
       }
     } catch (e) {
-      if ((e as Error).name === 'AbortError') {
-        // Timeout - knight doesn't support introspect
-        setError(null)
-        setEntries([])
-        setTreeNodes([])
-      } else {
-        setError(e instanceof Error ? e.message : 'Failed to fetch session data')
-      }
+      setError(e instanceof Error ? e.message : 'Failed to fetch session data')
     } finally {
       setLoading(false)
     }
@@ -205,11 +193,8 @@ export function SessionsPage() {
     const results: Record<string, KnightSessionStats> = {}
     await Promise.all(knights.map(async k => {
       try {
-        const controller = new AbortController()
-        const timeout = setTimeout(() => controller.abort(), 5000)
-        const res = await fetch(`/api/fleet/${k.name}/session?type=stats`, { signal: controller.signal })
-        clearTimeout(timeout)
-        if (res.ok) {
+        const res = await fetchWithTimeout(`/api/fleet/${k.name}/session?type=stats`)
+        if (res && res.ok) {
           const data = await res.json()
           results[k.name] = { ...data, supported: true }
         }


### PR DESCRIPTION
The stacked PRs #130 (#122), #133 (#124), #134 (#125), and #137 (#128) were merged into their stack base `fix/go-test-build` *after* #129 had already landed on main — so their changes never reached main. This PR promotes the branch tip, which contains all four plus a clean merge of current main.

Verified on the merged tree: `go test ./...` + `go vet` clean, `npm run build` passes, vitest 86/86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)