### PR TITLE
fix: MissionCard null-crash + kubeconfig fallback for local dev

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect

--- a/api/main.go
+++ b/api/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // validKnightName matches alphanumeric knight names (prevents NATS injection)
@@ -261,11 +262,22 @@ func main() {
 	}
 	slog.Info("NATS connected", "url", natsURL)
 
-	// Connect to Kubernetes (in-cluster)
+	// Connect to Kubernetes (in-cluster, falling back to kubeconfig for local dev)
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		slog.Warn("K8s in-cluster config failed (running outside cluster?)", "error", err)
-	} else {
+		if cfg, kerr := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig(); kerr != nil {
+			slog.Warn("Kubeconfig fallback failed", "error", kerr)
+		} else {
+			config = cfg
+			err = nil
+			slog.Info("Using kubeconfig (local dev)")
+		}
+	}
+	if err == nil {
 		// Assign globals only on success — a typed-nil client would defeat the
 		// k8sClient != nil availability checks in handlers
 		if cs, csErr := kubernetes.NewForConfig(config); csErr != nil {

--- a/ui/src/components/MissionCard.tsx
+++ b/ui/src/components/MissionCard.tsx
@@ -37,6 +37,10 @@ function MissionResults({ name }: { name: string }) {
 }
 
 export function MissionCard({ mission, onClick }: MissionCardProps) {
+  // Meta-missions start with no knights/chains — the API serializes those
+  // nil slices as null
+  const knights = mission.knights ?? []
+  const chains = mission.chains ?? []
   const [showResults, setShowResults] = useState(false)
   const [showKnights, setShowKnights] = useState(false)
   const [showChains, setShowChains] = useState(false)
@@ -104,7 +108,7 @@ export function MissionCard({ mission, onClick }: MissionCardProps) {
             <span className="text-xs text-gray-400">Knights</span>
           </div>
           <div className="flex gap-1">
-            {mission.knights.slice(0, 3).map((knight) => {
+            {knights.slice(0, 3).map((knight) => {
               const config = getKnightConfig(knight)
               return (
                 <span key={knight} className="text-sm" title={knight}>
@@ -112,8 +116,8 @@ export function MissionCard({ mission, onClick }: MissionCardProps) {
                 </span>
               )
             })}
-            {mission.knights.length > 3 && (
-              <span className="text-xs text-gray-500">+{mission.knights.length - 3}</span>
+            {knights.length > 3 && (
+              <span className="text-xs text-gray-500">+{knights.length - 3}</span>
             )}
           </div>
         </div>
@@ -124,7 +128,7 @@ export function MissionCard({ mission, onClick }: MissionCardProps) {
             <Link2 className="w-3 h-3 text-gray-400" />
             <span className="text-xs text-gray-400">Chains</span>
           </div>
-          <span className="text-sm text-white font-mono">{mission.chains.length}</span>
+          <span className="text-sm text-white font-mono">{chains.length}</span>
         </div>
       </div>
 

--- a/ui/src/hooks/useMissions.ts
+++ b/ui/src/hooks/useMissions.ts
@@ -30,8 +30,9 @@ export interface Mission {
   objective: string
   startedAt: string | null
   expiresAt: string | null
-  knights: string[]
-  chains: string[]
+  /** null until the planner/operator assigns knights (meta-missions start empty) */
+  knights: string[] | null
+  chains: string[] | null
   costBudgetUSD: string
   totalCost: string
   ttl: number


### PR DESCRIPTION
Found while verifying #144 against the live cluster by dispatching a real meta-mission.

## The crash (user-facing)

A fresh meta-mission has `knights: null` and `chains: null` in the API response (the operator hasn't assigned knights yet; Go serializes the nil slices as `null`). `MissionCard` did `mission.knights.slice(...)` / `.length` unguarded, so **the entire Missions page white-screened** (`ErrorBoundary caught: Cannot read properties of null (reading 'slice')`) the moment any meta-mission existed.

Fix: guard with `?? []` and make `knights`/`chains` nullable in the `Mission` type to match reality. Verified in-browser — the failed meta-mission card now renders (knights empty, chains 1, budget `$0.0000 / $1.00`) instead of crashing.

## Kubeconfig fallback (dev-only)

The API only did `rest.InClusterConfig()`, so it couldn't run locally against a cluster for exactly this kind of verification. Added a kubeconfig fallback when in-cluster config is unavailable; the in-cluster path is unchanged in production.

## Testing

- Reproduced the crash, applied the fix, confirmed the card renders via the live cluster (kubeconfig + NATS port-forward)
- Full page sweep (all 11 pages) clean — no console errors; WebSocket connects without the removed `api_key` param; dispatch returns a real `task_id`; chain metadata (description/suspended/run-counters/step retry) renders
- `mise run ui:typecheck` ✅  `ui:test` ✅ (90)  `go build`/`vet` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)