### PR TITLE
fix: short-circuit session/stats for offline knights instead of 504

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -703,24 +703,34 @@ func knightLogsHandler(namespace string) http.HandlerFunc {
 	}
 }
 
-// deriveIntrospectPrefix queries the Knight CRD to extract the NATS prefix for introspection.
-// This allows the dashboard to support multiple tables (fleet-a, chelonian, etc.) without hardcoding.
-func deriveIntrospectPrefix(ctx context.Context, knightName string) (string, error) {
+// getKnightCR fetches the Knight CR by name. The session handler uses it for
+// both readiness (status.ready/phase) and NATS prefix derivation with a single
+// API call.
+func getKnightCR(ctx context.Context, knightName string) (*unstructured.Unstructured, error) {
 	if dynClient == nil {
-		return "", fmt.Errorf("kubernetes client not available")
-	}
-
-	// Query the Knight CRD
-	gvr := schema.GroupVersionResource{
-		Group:    "ai.roundtable.io",
-		Version:  "v1alpha1",
-		Resource: "knights",
+		return nil, fmt.Errorf("kubernetes client not available")
 	}
 	namespace := envOr("NAMESPACE", "roundtable")
-	obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, knightName, metav1.GetOptions{})
+	obj, err := dynClient.Resource(knightGVR).Namespace(namespace).Get(ctx, knightName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to get knight %s: %w", knightName, err)
+		return nil, fmt.Errorf("failed to get knight %s: %w", knightName, err)
 	}
+	return obj, nil
+}
+
+// knightIsReady reports whether the operator marked the Knight as ready to
+// accept tasks (status.ready, mirrored by status.phase=Ready). The operator
+// derives this from deployment/pod readiness, so it doubles as a cheap
+// reachability signal for introspect requests.
+func knightIsReady(obj *unstructured.Unstructured) bool {
+	status := getNestedMap(obj.Object, "status")
+	return getBool(status, "ready") || getStr(status, "phase") == "Ready"
+}
+
+// deriveIntrospectPrefix extracts the NATS prefix for introspection from a Knight CR.
+// This allows the dashboard to support multiple tables (fleet-a, chelonian, etc.) without hardcoding.
+func deriveIntrospectPrefix(obj *unstructured.Unstructured) (string, error) {
+	knightName := obj.GetName()
 
 	// Extract .spec.nats.subjects[]
 	subjects, found, err := unstructured.NestedStringSlice(obj.Object, "spec", "nats", "subjects")
@@ -762,25 +772,42 @@ func knightSessionHandler(fleetPrefix string) http.HandlerFunc {
 			return
 		}
 
-		if nc == nil {
-			http.Error(w, "NATS not available", http.StatusServiceUnavailable)
-			return
-		}
-
 		// Validate knight name (prevents NATS subject injection)
 		if !validKnightName.MatchString(name) {
 			http.Error(w, "Invalid knight name", http.StatusBadRequest)
 			return
 		}
 
-		// Derive the NATS prefix from the Knight CRD so non-fleet-a knights
-		// (e.g. chelonian, rt-dev) are queried on their own table's subject
-		// instead of the hardcoded FLEET_PREFIX.
+		// Fetch the Knight CR once — it supplies both the readiness signal and
+		// the NATS prefix, so non-fleet-a knights (e.g. chelonian, rt-dev) are
+		// queried on their own table's subject instead of the hardcoded
+		// FLEET_PREFIX.
 		ctx := r.Context()
-		prefix, err := deriveIntrospectPrefix(ctx, name)
-		if err != nil {
-			slog.Warn("Failed to derive introspect prefix, falling back to FLEET_PREFIX", "knight", name, "error", err)
-			prefix = fleetPrefix // graceful degradation
+		prefix := fleetPrefix // graceful degradation when the CR is unavailable
+		if knightCR, err := getKnightCR(ctx, name); err != nil {
+			slog.Warn("Failed to fetch Knight CR, falling back to FLEET_PREFIX", "knight", name, "error", err)
+		} else {
+			// Short-circuit offline knights: proxying introspect to a knight
+			// whose pod is not ready just blocks until the NATS request timeout
+			// and surfaces as a 504 on the dashboard. Return the frontend's
+			// "no data" shape ({}) immediately instead — every caller guards on
+			// .session / .runtime / .entries / .nodes being present.
+			if !knightIsReady(knightCR) {
+				slog.Debug("Knight not ready, skipping introspect", "knight", name)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte("{}"))
+				return
+			}
+			if p, perr := deriveIntrospectPrefix(knightCR); perr == nil {
+				prefix = p
+			} else {
+				slog.Warn("Failed to derive introspect prefix, falling back to FLEET_PREFIX", "knight", name, "error", perr)
+			}
+		}
+
+		if nc == nil {
+			http.Error(w, "NATS not available", http.StatusServiceUnavailable)
+			return
 		}
 
 		// Forward a validated entry limit (pi-knight defaults to 20 for type=recent)

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -1854,3 +1854,104 @@ func TestHealthEndpointBypassesAuth(t *testing.T) {
 		t.Errorf("expected status=ok, got %s", response["status"])
 	}
 }
+
+// TestKnightSessionHandlerOfflineShortCircuit verifies that session/introspect
+// requests for knights that are not Ready return a fast empty 200 ({}) instead
+// of proxying to NATS and hanging until a 504 gateway timeout.
+func TestKnightSessionHandlerOfflineShortCircuit(t *testing.T) {
+	router := setupTestRouter()
+	nc = nil // NATS unavailable — the short-circuit must fire before any NATS use
+	t.Setenv("NAMESPACE", "test-namespace")
+	namespace := "test-namespace"
+
+	offline := makeTestKnightCR("lancelot", namespace, "infrastructure")
+	offline.Object["status"] = map[string]interface{}{"phase": "Provisioning"}
+	if _, err := dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, offline, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create knight CR: %v", err)
+	}
+
+	degraded := makeTestKnightCR("percival", namespace, "research")
+	degraded.Object["status"] = map[string]interface{}{"phase": "Degraded", "ready": false}
+	if _, err := dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, degraded, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create knight CR: %v", err)
+	}
+
+	for _, tt := range []struct {
+		knight      string
+		sessionType string
+	}{
+		{"lancelot", "stats"},
+		{"lancelot", "recent"},
+		{"lancelot", "tree"},
+		{"percival", "stats"},
+	} {
+		t.Run(tt.knight+"/"+tt.sessionType, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/fleet/%s/session?type=%s", tt.knight, tt.sessionType), nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200 for offline knight, got %d", w.Code)
+			}
+			if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("expected Content-Type application/json, got %s", ct)
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("expected valid JSON body, got %q: %v", w.Body.String(), err)
+			}
+			if len(body) != 0 {
+				t.Errorf("expected empty JSON object, got %v", body)
+			}
+		})
+	}
+}
+
+// TestKnightSessionHandlerReadyKnightProceedsToNATS verifies that Ready knights
+// are NOT short-circuited — the request proceeds to the NATS introspect proxy
+// (which reports 503 here because the test has no NATS connection).
+func TestKnightSessionHandlerReadyKnightProceedsToNATS(t *testing.T) {
+	router := setupTestRouter()
+	nc = nil
+	t.Setenv("NAMESPACE", "test-namespace")
+	namespace := "test-namespace"
+
+	// makeTestKnightCR sets status.phase=Ready
+	if _, err := dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, makeTestKnightCR("galahad", namespace, "security"), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create knight CR: %v", err)
+	}
+
+	// Readiness via status.ready=true (phase absent) must also pass through
+	readyBool := makeTestKnightCR("gawain", namespace, "docs")
+	readyBool.Object["status"] = map[string]interface{}{"ready": true}
+	if _, err := dynClient.Resource(knightGVR).Namespace(namespace).Create(nil, readyBool, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create knight CR: %v", err)
+	}
+
+	for _, knight := range []string{"galahad", "gawain"} {
+		req := httptest.NewRequest("GET", "/api/fleet/"+knight+"/session?type=stats", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("expected ready knight %s to reach the NATS proxy (503 with nil NATS), got %d", knight, w.Code)
+		}
+	}
+}
+
+// TestKnightSessionHandlerMissingCRFallsBack verifies graceful degradation:
+// when the Knight CR cannot be fetched the handler keeps the old proxy path
+// (FLEET_PREFIX fallback) instead of short-circuiting.
+func TestKnightSessionHandlerMissingCRFallsBack(t *testing.T) {
+	router := setupTestRouter()
+	nc = nil
+	t.Setenv("NAMESPACE", "test-namespace")
+
+	req := httptest.NewRequest("GET", "/api/fleet/unknown-knight/session?type=stats", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected fallback to NATS proxy (503 with nil NATS), got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Problem

`/api/fleet/{knight}/session?type=stats` (and `type=recent` / `type=tree`) proxies an introspect request to the knight over NATS (`<prefix>.introspect.<Knight>`). When the target knight is offline or not Ready, nothing answers that subject, so the request blocks until timeout and surfaces as a **504 Gateway Timeout**. The Command Center and Cost pages fan these requests out across the whole fleet, producing multi-second hangs and 504 noise for every offline knight.

## Fix

The handler already fetched the Knight CR (via the dynamic K8s client) to derive the per-table NATS prefix. This PR reuses that **single existing CR Get** as the readiness source instead of adding any new watch/informer:

- `knightIsReady()` checks the operator-maintained `status.ready` bool (mirrored by `status.phase == "Ready"`), which the operator sets from deployment/pod readiness.
- If the knight is **not ready**, the handler immediately returns `200` with an empty JSON object `{}` — no NATS round-trip at all.
- If the knight **is ready**, behavior is unchanged: derive the prefix from the CR and proxy over NATS.
- If the CR can't be fetched (K8s unavailable / unknown knight), the old graceful-degradation path is kept: fall back to `FLEET_PREFIX` and proxy with the existing **5s NATS request timeout** as defense-in-depth, so the worst case is a bounded 5s, never a 30s ingress hang.

## Response shape

The short-circuit body is `{}`. Every frontend consumer already treats missing fields as "no data":

- `useKnightSession.fetchStats` / `Sessions.tsx` spread the body and render only behind `stats?.session` / `stats?.runtime` guards
- `Dashboard.tsx` cost aggregation reads `r.value?.session?.cost` (optional-chained)
- `recent`/`tree` consumers read `data.entries || []` / `data.nodes || []`

So an offline knight now renders identically to an "introspect unsupported" knight, just instantly.

## Tests

`api/main_test.go`:
- `TestKnightSessionHandlerOfflineShortCircuit` — Provisioning and Degraded knights return fast `200` + empty JSON object for all three session types, with NATS nil (proves no NATS involvement)
- `TestKnightSessionHandlerReadyKnightProceedsToNATS` — Ready knights (via `phase=Ready` and via `ready=true`) still reach the NATS proxy path
- `TestKnightSessionHandlerMissingCRFallsBack` — unknown knight keeps the FLEET_PREFIX fallback path

`mise run ui:api-test` passes. No `ui/` changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)