### PR TITLE
fix: keep dashboard NATS connection alive so the live feed stops flapping

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -246,9 +246,27 @@ func main() {
 	fleetPrefix := envOr("FLEET_PREFIX", "fleet-a")       // NATS subject prefix (#23)
 	fleetStream := envOr("FLEET_STREAM", "fleet_a_results") // JetStream stream name
 
-	// Connect to NATS
+	// Connect to NATS. Reconnect forever: NATS can restart underneath a
+	// long-lived dashboard pod, and the nats.go defaults (MaxReconnects=60)
+	// give up after ~2min and permanently close the connection — every WS
+	// then flaps "connected/disconnected" and introspect calls fail with
+	// "nats: connection closed" until the pod is manually restarted.
 	var err error
-	nc, err = nats.Connect(natsURL)
+	nc, err = nats.Connect(natsURL,
+		nats.MaxReconnects(-1), // never give up
+		nats.ReconnectWait(2*time.Second),
+		nats.ReconnectJitter(500*time.Millisecond, 2*time.Second),
+		nats.RetryOnFailedConnect(true), // don't hard-exit if NATS is briefly down at boot
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			slog.Warn("NATS disconnected, will retry", "error", err)
+		}),
+		nats.ReconnectHandler(func(c *nats.Conn) {
+			slog.Info("NATS reconnected", "url", c.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			slog.Error("NATS connection permanently closed")
+		}),
+	)
 	if err != nil {
 		slog.Error("NATS connect failed", "error", err, "url", natsURL)
 		os.Exit(1)
@@ -1008,6 +1026,17 @@ func briefingHandler(vaultPath string) http.HandlerFunc {
 
 func wsHandler(fleetPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Check NATS health BEFORE upgrading (#19). Upgrading first and then
+		// closing makes the client fire onopen (UI shows "Connected") before
+		// the close arrives, so the indicator flickers connected/disconnected
+		// on every reconnect. Rejecting the upgrade with 503 keeps the client
+		// cleanly "Disconnected" while the backend is degraded.
+		if !nc.IsConnected() {
+			slog.Warn("NATS not connected, rejecting WS")
+			http.Error(w, "NATS unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			slog.Error("WebSocket upgrade error", "error", err)
@@ -1032,14 +1061,7 @@ func wsHandler(fleetPrefix string) http.HandlerFunc {
 		// Done channel to clean up NATS subscriptions when WS closes
 		done := make(chan struct{})
 
-		// Subscribe to all task and result events (#19: check NATS connection health)
-		if !nc.IsConnected() {
-			slog.Warn("NATS not connected, rejecting WS")
-			conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "NATS unavailable"))
-			conn.Close()
-			return
-		}
-
+		// Subscribe to all task and result events
 		taskSub, err := nc.Subscribe(fleetPrefix+".tasks.>", func(msg *nats.Msg) {
 			select {
 			case <-done:

--- a/ui/src/hooks/useWebSocket.tsx
+++ b/ui/src/hooks/useWebSocket.tsx
@@ -66,6 +66,12 @@ function useWebSocketConnection() {
     ws.onclose = (e) => {
       if (!mountedRef.current) return
       setConnected(false)
+      // Surface the close reason for diagnosis. The API returns a 503 on the
+      // upgrade when its NATS connection is down (browsers report that as a
+      // reasonless code-1006 close), and a clean shutdown sends 1011 with a
+      // reason — either way, don't silently show a bare "Disconnected".
+      const reason = e.reason || (e.code === 1006 ? 'live feed unreachable (backend may be starting or NATS is down)' : `closed (code ${e.code})`)
+      setError(reason)
 
       // Exponential backoff reconnect with jitter (#37)
       const delay = jitter(reconnectDelay.current)


### PR DESCRIPTION
## The bug

The dashboard's "🟢 Live / 🔴 Disconnected" indicator was flapping on the live cluster. It looked like a forward-auth problem but wasn't — the `/api/ws` upgrade authenticates fine. Verified against the live dashboard from the browser:

- The WS **opens** in ~25ms, then the server **force-closes it ~1s later** with `close code 1011, reason "NATS unavailable"` — 6/6 probes, consistently.
- NATS-backed REST was also down: `/api/tasks` → 500 `Task history unavailable`, `/api/fleet/*/session?type=stats` → 504 `Knight introspection timeout`. K8s-backed endpoints (`/api/fleet`, `/api/chains`) returned 200.

## Root cause

`api/main.go` connected with a bare `nats.Connect(natsURL)`, inheriting the nats.go defaults (`MaxReconnects=60`, `ReconnectWait=2s`). `nats-0` had restarted underneath the 16h-old dashboard pod; the client retried for ~2 min, hit the cap, and **permanently closed** the connection. Pod logs confirmed the sequence: `NATS connected` at startup → later `nats: connection closed` on every introspect → a solid wall of `NATS not connected, rejecting WS`. It had been dead ~5.7h and would not self-heal without a restart.

The visible flicker: the handler *accepts* the upgrade (client fires `onopen` → shows Connected), *then* closes it because NATS is down (→ Disconnected), reconnects 3s later, repeat.

## Changes

- **Reconnect forever.** `MaxReconnects(-1)` + jittered backoff + `RetryOnFailedConnect(true)`, plus disconnect/reconnect/closed handlers for visibility. The connection now self-heals across NATS restarts.
- **Check NATS *before* the WS upgrade**, rejecting with `503` instead of upgrading-then-closing. This removes the false "Connected" flash that caused the flicker; the client stays cleanly "Disconnected" while the backend is degraded.
- **Surface the WS close reason/code** in the hook's `error` state instead of a bare "Disconnected", so a degraded backend is diagnosable from the browser next time.

## Testing

- `go build` / `go vet` / `go test ./...` — pass
- `tsc -b` typecheck + `vitest run src/hooks` — pass
- Restarted the live dashboard pod to restore service; new pod reconnected to NATS immediately (0 WS rejections since). Post-fix browser probes now hold the WS open the full 3s and receive live messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)