### PR TITLE
fix: legible Session Explorer tree indent and timeline message labels

### DIFF
--- a/ui/src/pages/Sessions.test.tsx
+++ b/ui/src/pages/Sessions.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ToolCallCard, TreeNodeView } from './Sessions'
+import type { SessionEntry, SessionTreeNode } from '../hooks/useKnightSession'
+
+function entry(over: Partial<SessionEntry>): SessionEntry {
+  return { id: 'e1', parentId: null, type: 'message', timestamp: '2026-07-08T06:05:35Z', ...over }
+}
+
+describe('ToolCallCard timeline legibility', () => {
+  it('shows a role-based label instead of a bare "message" when text is empty', () => {
+    render(<ToolCallCard entry={entry({ type: 'message', role: 'assistant', text: '' })} />)
+    // Regression: previously collapsed to the wire type "message"
+    expect(screen.getByText('assistant message')).toBeInTheDocument()
+    expect(screen.queryByText('message')).not.toBeInTheDocument()
+  })
+
+  it('prefers real text content when present', () => {
+    render(<ToolCallCard entry={entry({ role: 'user', text: 'Generate the digest' })} />)
+    expect(screen.getByText('Generate the digest')).toBeInTheDocument()
+  })
+
+  it('keeps the timestamp on a single line (no wrap)', () => {
+    render(<ToolCallCard entry={entry({ role: 'assistant', text: 'hi' })} />)
+    const ts = screen.getByText((_, el) => el?.textContent?.includes(':05:') ?? false, { selector: 'span' })
+    expect(ts.className).toContain('whitespace-nowrap')
+  })
+})
+
+describe('TreeNodeView indentation', () => {
+  function node(over: Partial<SessionTreeNode>): SessionTreeNode {
+    return { id: 'n1', parentId: null, type: 'message', timestamp: '2026-07-08T06:00:00Z', childrenCount: 0, summary: 'user: hello', ...over }
+  }
+
+  it('caps indent so deep chains do not march off-screen', () => {
+    const { container } = render(<TreeNodeView node={node({})} depth={40} />)
+    const padded = container.querySelector('[style*="padding-left"]') as HTMLElement
+    // 12 (cap) * 16px, not 40 * 16 = 640px
+    expect(padded.style.paddingLeft).toBe('192px')
+  })
+
+  it('shallow nodes still indent proportionally', () => {
+    const { container } = render(<TreeNodeView node={node({})} depth={3} />)
+    const padded = container.querySelector('[style*="padding-left"]') as HTMLElement
+    expect(padded.style.paddingLeft).toBe('48px')
+  })
+})

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -25,25 +25,37 @@ const entryTypeColors: Record<string, string> = {
   compaction: 'border-red-500/30 bg-red-500/5',
 }
 
-function TreeNodeView({ node, depth = 0 }: { node: SessionTreeNode & { children?: SessionTreeNode[] }; depth?: number }) {
+// Cap the visual indent so a long, near-linear parent→child chain doesn't
+// march the content off the right edge (and squeeze the timestamp into a wrap).
+const MAX_TREE_INDENT_DEPTH = 12
+const TREE_INDENT_PX = 16
+
+export function TreeNodeView({ node, depth = 0 }: { node: SessionTreeNode & { children?: SessionTreeNode[] }; depth?: number }) {
   const [expanded, setExpanded] = useState(depth < 2)
   const hasChildren = (node.children?.length ?? 0) > 0
+  const indent = Math.min(depth, MAX_TREE_INDENT_DEPTH) * TREE_INDENT_PX
 
   return (
-    <div style={{ marginLeft: depth * 16 }}>
+    <div>
       <div
-        className="flex items-center gap-2 py-1 px-2 rounded hover:bg-roundtable-steel/30 cursor-pointer text-sm"
+        className="flex items-center gap-2 py-1 pr-2 rounded hover:bg-roundtable-steel/30 cursor-pointer text-sm"
         onClick={() => setExpanded(e => !e)}
       >
-        {hasChildren ? (
-          expanded ? <ChevronDown className="w-3 h-3 text-gray-500" /> : <ChevronRight className="w-3 h-3 text-gray-500" />
-        ) : <span className="w-3" />}
-        <span>{entryTypeIcons[node.type] || '●'}</span>
-        <span className="text-gray-300 truncate flex-1">{node.summary || node.label || node.type}</span>
+        {/* Indented label region — only this shrinks/truncates, keeping the
+            timestamp pinned to a fixed right column. */}
+        <div className="flex items-center gap-2 min-w-0 flex-1" style={{ paddingLeft: indent }}>
+          {hasChildren ? (
+            expanded
+              ? <ChevronDown className="w-3 h-3 text-gray-500 shrink-0" />
+              : <ChevronRight className="w-3 h-3 text-gray-500 shrink-0" />
+          ) : <span className="w-3 shrink-0" />}
+          <span className="shrink-0">{entryTypeIcons[node.type] || '●'}</span>
+          <span className="text-gray-300 truncate">{node.summary || node.label || node.type}</span>
+        </div>
         {node.childrenCount > 0 && (
-          <span className="text-xs text-gray-600">{node.childrenCount}</span>
+          <span className="text-xs text-gray-600 shrink-0">{node.childrenCount}</span>
         )}
-        <span className="text-xs text-gray-600">{formatTimestamp(node.timestamp)}</span>
+        <span className="text-xs text-gray-600 shrink-0 whitespace-nowrap tabular-nums">{formatTimestamp(node.timestamp)}</span>
       </div>
       {expanded && hasChildren && (
         <div>
@@ -56,27 +68,61 @@ function TreeNodeView({ node, depth = 0 }: { node: SessionTreeNode & { children?
   )
 }
 
-function ToolCallCard({ entry }: { entry: SessionEntry }) {
+// Message entries carry a `role` but a shared `type` of "message"; resolve a
+// legible icon/color/label from the role so they don't all render as "message".
+function roleIcon(role?: string): string {
+  return role === 'user' ? '📨' : role === 'assistant' ? '🤖' : '💬'
+}
+
+function entryIcon(entry: SessionEntry): string {
+  if (entry.type === 'message') return roleIcon(entry.role)
+  return entryTypeIcons[entry.type] || '●'
+}
+
+function entryColor(entry: SessionEntry): string {
+  if (entry.type === 'message') {
+    return entry.role === 'user' ? entryTypeColors.user
+      : entry.role === 'assistant' ? entryTypeColors.assistant
+      : 'border-gray-500/30 bg-gray-500/5'
+  }
+  return entryTypeColors[entry.type] || 'border-gray-500/30 bg-gray-500/5'
+}
+
+// Never collapse to the bare wire type ("message"); prefer real text, then a
+// role/tool descriptor. Returns whether the label is a placeholder so the UI
+// can render it muted.
+function entryLabel(entry: SessionEntry): { text: string; placeholder: boolean } {
+  const text = entry.text?.trim()
+  if (text) return { text, placeholder: false }
+  if (entry.type === 'message' && entry.role) {
+    return { text: `${entry.role} message`, placeholder: true }
+  }
+  if (entry.toolName) return { text: entry.toolName, placeholder: false }
+  return { text: entry.type, placeholder: true }
+}
+
+export function ToolCallCard({ entry }: { entry: SessionEntry }) {
   const [expanded, setExpanded] = useState(false)
+  const label = entryLabel(entry)
 
   return (
     <div
-      className={`border rounded-lg p-3 cursor-pointer transition-colors ${entryTypeColors[entry.type] || 'border-gray-500/30 bg-gray-500/5'}`}
+      className={`border rounded-lg p-3 cursor-pointer transition-colors ${entryColor(entry)}`}
       onClick={() => setExpanded(e => !e)}
     >
       <div className="flex items-center gap-2 text-sm">
-        <span>{entryTypeIcons[entry.type] || '●'}</span>
+        <span className="shrink-0">{entryIcon(entry)}</span>
         {entry.toolName && (
-          <span className="font-mono text-purple-400 text-xs bg-purple-500/10 px-1.5 py-0.5 rounded">{entry.toolName}</span>
+          <span className="font-mono text-purple-400 text-xs bg-purple-500/10 px-1.5 py-0.5 rounded shrink-0">{entry.toolName}</span>
         )}
-        <span className="text-gray-400 truncate flex-1">{entry.text || entry.toolName || entry.type}</span>
+        <span className={`truncate flex-1 min-w-0 ${label.placeholder ? 'text-gray-500 italic' : 'text-gray-400'}`}>{label.text}</span>
         {entry.cost != null && entry.cost > 0 && (
-          <span className="text-roundtable-gold text-xs">{formatCost(entry.cost)}</span>
+          <span className="text-roundtable-gold text-xs shrink-0">{formatCost(entry.cost)}</span>
         )}
         {entry.tokens && (
-          <span className="text-gray-600 text-xs">{entry.tokens.input + entry.tokens.output}t</span>
+          <span className="text-gray-600 text-xs shrink-0">{entry.tokens.input + entry.tokens.output}t</span>
         )}
-        <span className="text-gray-600 text-xs">{formatTimestamp(entry.timestamp)}</span>
+        <span className="text-gray-600 text-xs shrink-0 whitespace-nowrap tabular-nums">{formatTimestamp(entry.timestamp)}</span>
       </div>
       {expanded && (
         <div className="mt-2 space-y-2 border-t border-roundtable-steel/30 pt-2">


### PR DESCRIPTION
## Problem

The Session Explorer had two rendering bugs making the tree/timeline hard to read:

1. **Tree view — diagonal staircase + wrapping timestamps.** `TreeNodeView` applied `marginLeft: depth * 16` to the whole row with no cap. Sessions are near-linear parent→child chains, so every entry nested one level deeper and marched text off the right edge; the timestamp shared the flex row without `whitespace-nowrap` and wrapped ("6:00:45 / AM").
2. **Timeline view — bare "message" rows.** `ToolCallCard` rendered `entry.text || entry.toolName || entry.type`. pi-knight's `buildRecent` only populates `text` for user/assistant messages with actual text blocks; tool-only/non-text messages come back with empty `text`, so the label collapsed to the wire type `"message"` and the icon fell back to `●`. The `role` field was returned but ignored.

## Fix

- **Tree:** cap indent at depth 12, move it onto an inner `min-w-0 flex-1` label region, and pin timestamp + child-count to a fixed `shrink-0 whitespace-nowrap` right column.
- **Timeline:** `entryIcon`/`entryColor`/`entryLabel` helpers resolve a message's `role` into a proper icon (📨/🤖/💬), color, and label — empty-text messages read as e.g. *"assistant message"* (muted) instead of `message`, real text still preferred.

## Tests

- `tsc -b` clean; full suite 95/95.
- New `ui/src/pages/Sessions.test.tsx` pins both regressions (empty message → role label; `depth=40` caps at 192px; timestamp `whitespace-nowrap`).

## Follow-up (not in this PR)

The redundant text-less message shells originate in `pi-knight` `introspect.ts` `buildRecent`. This PR renders them legibly; suppressing them entirely would be a separate pi-knight change.